### PR TITLE
Move reading pool to handbook

### DIFF
--- a/reading-pool.md
+++ b/reading-pool.md
@@ -1,0 +1,82 @@
+Reading Pool
+============
+
+:::info  
+**Legend**  
+:globe_with_meridians: Web/online resources `:globe_with_meridians:`  
+:page_facing_up: PDF reports or articles `:page_facing_up:`  
+:speaker: Audio`:speaker:`  
+:clapper: Video `:clapper:`  
+:bulb: Wild ideas `:bulb:`  
+:::  
+
+
+**7 International Co-operative Principles**: ***
+- :globe_with_meridians: [ICA Cooperative identity, values & principles](https://www.ica.coop/en/whats-co-op/co-operative-identity-values-principles)
+- :page_facing_up: [ICA Guidance Notes to the Co-operative Principles](https://www.ica.coop/sites/default/files/publication-files/ica-guidance-notes-en-310629900.pdf)
+- :globe_with_meridians: [Willy Street Seven Cooperative Principles](https://www.willystreet.coop/seven-cooperative-principles)
+- :globe_with_meridians: [Grassroots Economic Organizing: The Cooperative Principles, the Common Good, and Solidarity](http://www.geo.coop/story/cooperative-principles-common-good-and-solidarity)
+
+Tech Worker Co-ops:
+- :page_facing_up: [A technology freelancer's guide to starting a worker's coop](https://cryptography.dog/TechCoopHOWTO.pdf)
+- :speaker: Soundcloud Podcast: [Worker Cooperatives: Widening Spheres of Democracy](https://www.upstreampodcast.org/workercoops1)
+- :globe_with_meridians: Tech Worker Co-op Repo: [Incredible list of resources including a db of active tech co-ops worldwide](https://github.com/hng/tech-coops)
+- :globe_with_meridians: [Vibes Theory of Organization Design - Enspiral](http://richdecibels.com/stories/vibes-theory/vibes-theory.html)
+    - identifies lots of tensions while building organizational culture
+- :globe_with_meridians: [Enspiral Handbook](https://handbook.enspiral.com/)
+    - *** **Important [People Agreement](https://handbook.enspiral.com/agreements/people.html)**
+    - Resource [Git for Beginners](https://handbook.enspiral.com/guides/github_for_beginners.html)
+    - Related [Root Systems "Pod"](https://www.rootsystems.nz/)
+- :globe_with_meridians: [Lab.coop Reading List](http://www.lab.coop/blog/share-more-to-have-more-why-lab-coop-is-an-employee-owned-hol)
+- :page_facing_up: [Balancing Performance with Principles in Coops and Mutuals, Report by Ernst and Young](https://www.ey.com/Publication/vwLUAssets/Enlightened_co-operative_governance/$FILE/Enlightened%20co-operative%20governance_EN.pdf)
+- :bulb: Some form of co-op member interviewing?
+
+Civics, Tech, Politics:
+- :globe_with_meridians: [Paul Frazee "Information Civics"](https://infocivics.com/)
+- :page_facing_up: [Langdon Winner "Do Artifacts have Politics"](https://www.cc.gatech.edu/~beki/cs4001/Winner.pdf)
+- :globe_with_meridians: [Diana Nucera "Two-way Streets: Forging the Paths Towards Participatory Civic Technology"](https://civicquarterly.com/article/two-way-streets/)
+- :globe_with_meridians: [Design Justice Principles](http://designjusticenetwork.org/network-principles/)
+- :globe_with_meridians: [From "Openness" to Justice](http://hackeducation.com/2014/11/16/from-open-to-justice)
+- :page_facing_up: [Indigenous Cooperatives in Canada: The Complex Relationship Between Cooperatives, Community Economic Development, Colonization, and Culture](http://www.jeodonline.com/sites/jeodonline.com/files/articles/2015/08/13/6sengupta13aug2015.pdf)
+
+Collaboration, Methodologies (Could be merged with the above?? 🤔):
+- :globe_with_meridians: [Study Collaboration](http://studycollaboration.com)
+    - Thinking about novel ways of collaborating between us and others
+    - Also, neat links towards the bottom
+- :globe_with_meridians: [Patterns for Decentralised Organising](https://github.com/rdbartlett/patterns)
+- :globe_with_meridians: [Designing Methodologies 2018, Shannon Mattern](http://www.wordsinspace.net/designingmethods/spring2018/)
+- :globe_with_meridians: [Aspiration Tech Facilication Resources](https://facilitation.aspirationtech.org/index.php?title=Main_Page)
+- :globe_with_meridians: [Beautiful Trouble: A Toolbox for Revolution](http://beautifultrouble.org/)
+- :books: [adrienne maree brown (2017) *Emergent Strategy: Shaping Change, Changing Worlds*](https://www.akpress.org/emergentstrategy.html) (dawn has a copy)
+- :globe_with_meridians: [Loconomics Cooperative Bylaws](https://loconomics.gitbooks.io/loconomics-cooperative-bylaws/content/)
+- :globe_with_meridians: [Waag Co-creation Toolkit](https://co-creation.waag.org/)
+- :bulb: Wild idea for a first group activity: Make a beautiful zine
+- :globe_with_meridians: [El LleialTec: Pla de Sobirania Tecnològica als equipaments municipals](https://tec.lleialtat.cat/) ([Google translated](https://translate.google.ca/translate?hl=en&sl=ca&tl=en&u=https%3A%2F%2Ftec.lleialtat.cat))
+
+New Economies:
+- :globe_with_meridians: [Center for Global Justice: Solidarity Economy Directory](https://globaljusticecenter.org/solidarity-economy-directory/International)
+- :globe_with_meridians: [The Future of Social Economy Leadership and Organizational Composition in Canada: Demand from Demographics, and Difference through Diversity](https://journals.openedition.org/interventionseconomiques/2794)
+
+Commons, anti-capitalism:
+- :books: Elinor Ostrom (1990) *Governing the Commons* (dawn has a copy)
+    - :globe_with_meridians: [8 principles for designing common pool resources](http://www.onthecommons.org/magazine/elinor-ostroms-8-principles-managing-commmons)
+- :page_facing_up: JK Gibson-Graham, J Cameron, & S Healy (2016) "Commoning as a postcapitalist politics" In *Releasing the Commons: Rethinking the futures of the commons*
+- :page_facing_up: G Caffentzis, S Frederici (2014) "Commons against and beyond capitalism"
+- :page_facing_up: S Frederici (2011) "Feminism and the politics of the commons"
+    - **Talk in Toronto**: :calendar: [22 Jan 2019, 16:00-18:00](http://complit.utoronto.ca/events/silvia-federicis-public-lecture-tba/)
+- :page_facing_up: Yochai Benkler [Commons-Based Peer Production and Virtue](https://nissenbaum.tech.cornell.edu/papers/jopp_235.pdf)
+- :page_facing_up: Stavros Stavrides [Common Space: The City as Commons](https://zajednicko.org/mreznabibliografija/wp-content/uploads/sites/2/2018/04/Stavrides-Stavros_Common-Space-The-City-as-Commons.pdf)
+- :clapper: Richard Sennett [The Decline of the Skills Society](https://www.youtube.com/watch?v=mjd5iM42APA)
+- :globe_with_meridians: Scott Alexander [Meditations On Moloch](https://slatestarcodex.com/2014/07/30/meditations-on-moloch/)
+
+Reqs for co-ops in Canada (Federal, Ontario) see [**research document**](https://hackmd.io/s/SJwTqa767#):
+- :page_facing_up: [Registering a coop - Official Guide by Financial Services Commision of Ontario](https://www.fsco.gov.on.ca/en/coops/Documents/register_co-ops-guide.pdf)
+- :page_facing_up: [Ontario.coop fact sheets](https://ontario.coop/sites/default/files/Complete%20list%20of%20FACTSheets%20-%20Updated.pdf)
+- :globe_with_meridians: [Industry Canada Starting a Federal co-op](https://www.ic.gc.ca/eic/site/106.nsf/eng/h_00073.html#federal)
+- :globe_with_meridians: [Industry Canada Starting an ON co-op](https://www.ic.gc.ca/eic/site/106.nsf/eng/h_00073.html#ontario)
+- :globe_with_meridians: [Ontario.coop Starting a co-operative](https://www.ontario.coop/starting-co-operative)
+
+Why decentralize?
+- :clapper: Sarah Friend [Decentralization and its Discontents](https://www.youtube.com/watch?v=Km6EYsBYAlY) at Radical Networks 2018
+- :page_facing_up: Nathan Schnieder n.d. "Decentralization: An Incomplete Ideology" (ask dawn for pdf)
+- :globe_with_meridians: [Data Together Reading List](https://github.com/datatogether/reading_datatogether) or [Zotero Group](https://www.zotero.org/groups/datatogether)


### PR DESCRIPTION
Had a major brainwave of readings I want to add, but still feel like the organizing repo isn't the right place. 

In keeping with the spirit of discussion in https://github.com/hyphacoop/organizing/pull/38 I'm going to keep the same format but suggest we put it here for now.

See related: https://github.com/hyphacoop/organizing/pull/45