### PR TITLE
Add onboarding page and initial guide for voicemails

### DIFF
--- a/guides.md
+++ b/guides.md
@@ -109,41 +109,28 @@ Instructions:
 
 ### Accessing Voicemail 
 
-Voicemail is received by email to [members@hypha.coop](mailto:members@hypha.coop).
+We use a VoIP phone line provider with forwarding and voicemail from [FreePhoneLine.ca](https://www.freephoneline.ca/login). It helps us:
+
+- Have a phone number without tying it to a physical location
+- Receive voicemail by email to [members@hypha.coop](mailto:members@hypha.coop)
+
+To access voicemail inbox you can either call remotely or through a configured SIP client.
+
+- Remotely:
+  1. Call the dial-in number `14164770355`
+  1. Enter our account number `14378876936`
+  1. Enter our password: <in our shared password manager [Passbolt](https://pass.hypha.coop/auth/login)>
+- SIP client: 
+  Dial `*98`
 
 ### Managing Voicemail and Phone Forwarding
 
-accessing
-changing greetings
-where to look for info
+To record or update the voicemail greeting [access the voicemail](#accessing-voicemail) per above and select the following options:
 
-Record/Change Greeting
-
-
-
-### Login to voice mail
-
-### Remotely
-
-Dial in number: 14164770355 
-Account number: 14378876936
-Password: in password respository
-
-### Sip Client
-
-Dial *98
-
-## Voice mail greeting
-
-Personal Options - 3
-Greetings - 3
-Personal Greeting 2 
-To record personal greeting press 2
-
-
-
-
-
+- 3 - Personal options
+- 3 - Greetings 
+- 2 - Personal greeting 
+- 2 - Record a personal greeting
 
 ### References
 
@@ -157,3 +144,4 @@ To record personal greeting press 2
    [meetings]: https://link.hypha.coop/meetings
    [template]: https://link.hypha.coop/template
    [calendar]: https://link.hypha.coop/calendar
+   [service-inventory]: https://hackmd.io/WXS9Ie9wQ8OlmIhSpDpdmw?view

--- a/guides.md
+++ b/guides.md
@@ -15,7 +15,9 @@ different situations. As such, they are normative, or premised on values,
 morals, and an idea of how things ought to be done. They are a manifestation of
 our values.
 
-## Scheduling a meeting
+## Meetings
+
+### Scheduling a meeting
 
 Note: Consider whether this meeting might be a global interest to other
 members. Skip the steps below at your discretion for low-stakes topics.
@@ -44,7 +46,7 @@ members. Skip the steps below at your discretion for low-stakes topics.
   - Check on non-responders in following days and send (gentle)
     reminders as needed
 
-## Hosting a meeting
+### Hosting a meeting
 
 - **Before** the meeting...
   - create a stub agenda as soon as possible (can be done before scheduling)
@@ -69,7 +71,9 @@ members. Skip the steps below at your discretion for low-stakes topics.
   - as needed, send reminders of action items
   - migrate action items into task tracker
 
-## Managing shortlinks
+## Shortlinks
+
+### Managing shortlinks
 
 We use a custom shortlink service at `link.hypha.coop`. It helps us:
 - resolve keywords to URLs from any computer,
@@ -80,7 +84,7 @@ We use a custom shortlink service at `link.hypha.coop`. It helps us:
 Instructions on creating and managing shortlinks are available in
 our [`shortlinks` repo](https://github.com/hyphacoop/shortlinks).
 
-## Accessing shortlinks
+### Accessing shortlinks
 
 > **Hint:** You can use a URL hash to deep-link into an expanded shortlink.
 > Example:&nbsp;http://link.hypha.coop/inventory#MailCow
@@ -100,6 +104,46 @@ engine set in browser](https://i.imgur.com/2D8B7kS.gif)
 Instructions:
 [Chrome](https://www.techrepublic.com/article/pro-tip-add-custom-search-engines-in-chrome-for-more-efficient-searching/)
 | [Firefox (requires extension)](https://addons.mozilla.org/en-US/firefox/addon/add-custom-search-engine/)
+
+## Voicemail
+
+### Accessing Voicemail 
+
+Voicemail is received by email to [members@hypha.coop](mailto:members@hypha.coop).
+
+### Managing Voicemail and Phone Forwarding
+
+accessing
+changing greetings
+where to look for info
+
+Record/Change Greeting
+
+
+
+### Login to voice mail
+
+### Remotely
+
+Dial in number: 14164770355 
+Account number: 14378876936
+Password: in password respository
+
+### Sip Client
+
+Dial *98
+
+## Voice mail greeting
+
+Personal Options - 3
+Greetings - 3
+Personal Greeting 2 
+To record personal greeting press 2
+
+
+
+
+
 
 ### References
 

--- a/meetings.md
+++ b/meetings.md
@@ -3,7 +3,7 @@
 The purpose of this resource is to share details about how and when we
 meet.
 
-We have specific Guides for [scheduling][scheduling] and
+We have specific guides for [scheduling][scheduling] and
 [hosting][hosting] meetings.
 
 **Contents**

--- a/onboarding.md
+++ b/onboarding.md
@@ -23,8 +23,5 @@ In place of a physical meeting place we have virtual office comprised of the fol
 
 We also have the following "helper" tools to navigate these spaces:
 
-- [Service Inventory]()
+- [Service Inventory](https://hackmd.io/WXS9Ie9wQ8OlmIhSpDpdmw?view)
 - Link Shortner: [link.hypha.coop](https://link.hypha.coop)
-
-
-- 

--- a/onboarding.md
+++ b/onboarding.md
@@ -15,10 +15,10 @@ We also have the following communication and contact methods:
 
 In place of a physical place we have virtual office comprised of the following spaces:
 
-- Matrix Chat
-- Loomio
-- GitHub Organization
-- Google Drive (with both priviledged and public folders)
+- [Matrix Chat][matrix-chat]: `chat.tomesh.net`
+- [Loomio][loomio]: `loomio.hypha.coop`
+- [GitHub Organization](https://github.com/hyphacoop/), with a [task tracker][task-tracker]
+- [Google Drive][google-drive] (with both priviledged and public folders)
 
 We also have the following "helper" tools to navigate these spaces:
 
@@ -31,3 +31,7 @@ We also have the following "helper" tools to navigate these spaces:
 [service-inventory]: https://hackmd.io/WXS9Ie9wQ8OlmIhSpDpdmw?view
 [accessing-vm]: /guides.md#accessing-voicemail
 [managing-vm]: /guides.md#managing-voicemail-and-phone-forwarding
+[matrix-chat]: https://chat.tomesh.net/#/group/+hyphacoop:tomesh.net
+[loomio]: https://loomio.hypha.coop
+[task-tracker]: https://github.com/orgs/hyphacoop/projects/2
+[google-drive]: http://link.hypha.club/drive

--- a/onboarding.md
+++ b/onboarding.md
@@ -13,7 +13,7 @@ We also have the following communication and contact methods:
 
 ## Our Virtual Office
 
-In place of a physical meeting place we have virtual office comprised of the following spaces:
+In place of a physical place we have virtual office comprised of the following spaces:
 
 - Matrix Chat
 - Loomio
@@ -23,11 +23,11 @@ In place of a physical meeting place we have virtual office comprised of the fol
 We also have the following "helper" tools to navigate these spaces:
 
 - [Service Inventory][service-inventory]
-- [Link Shortner][link-shortener]: [link.hypha.coop][link-shortener]
+- [Link Shortner][link-shortener]: `link.hypha.coop`
 
 
 <!-- Links -->
 [link-shortener]: https://link.hypha.coop/
 [service-inventory]: https://hackmd.io/WXS9Ie9wQ8OlmIhSpDpdmw?view
-[accessing-vm]: /guides.md#accessing-voicemai
+[accessing-vm]: /guides.md#accessing-voicemail
 [managing-vm]: /guides.md#managing-voicemail-and-phone-forwarding

--- a/onboarding.md
+++ b/onboarding.md
@@ -6,9 +6,8 @@ Welcome to Hypha! This page is supposed to help those getting situated in our or
 
 We also have the following communication and contact methods:
 
-- :telephone_receiver: 437-887-6936
-- :mailbox: #1308-1403 Royal York Road
-  Etobicoke, Ontario  M9P 0A1
+- :telephone_receiver: +1-437-887-6936 (We have specific guides for [Accessing][accessing-vm] and [Managing][managing-vm] Voicemail)
+- :mailbox: #1308-1403 Royal York Road, Etobicoke, Ontario  M9P 0A1
 - :link: [hypha.coop](https://hypha.coop)
 - :e-mail: hello@hypha.coop
 
@@ -19,9 +18,16 @@ In place of a physical meeting place we have virtual office comprised of the fol
 - Matrix Chat
 - Loomio
 - GitHub Organization
-- Google Drive 
+- Google Drive (with both priviledged and public folders)
 
 We also have the following "helper" tools to navigate these spaces:
 
-- [Service Inventory](https://hackmd.io/WXS9Ie9wQ8OlmIhSpDpdmw?view)
-- Link Shortner: [link.hypha.coop](https://link.hypha.coop)
+- [Service Inventory][service-inventory]
+- [Link Shortner][link-shortener]: [link.hypha.coop][link-shortener]
+
+
+<!-- Links -->
+[link-shortener]: https://link.hypha.coop/
+[service-inventory]: https://hackmd.io/WXS9Ie9wQ8OlmIhSpDpdmw?view
+[accessing-vm]: /guides.md#accessing-voicemai
+[managing-vm]: /guides.md#managing-voicemail-and-phone-forwarding

--- a/onboarding.md
+++ b/onboarding.md
@@ -1,0 +1,30 @@
+# Onboarding
+
+Welcome to Hypha! This page is supposed to help those getting situated in our organization.
+
+## Contacting Hypha 
+
+We also have the following communication and contact methods:
+
+- :telephone_receiver: 437-887-6936
+- :mailbox: #1308-1403 Royal York Road
+  Etobicoke, Ontario  M9P 0A1
+- :link: [hypha.coop](https://hypha.coop)
+- :e-mail: hello@hypha.coop
+
+## Our Virtual Office
+
+In place of a physical meeting place we have virtual office comprised of the following spaces:
+
+- Matrix Chat
+- Loomio
+- GitHub Organization
+- Google Drive 
+
+We also have the following "helper" tools to navigate these spaces:
+
+- [Service Inventory]()
+- Link Shortner: [link.hypha.coop](https://link.hypha.coop)
+
+
+- 


### PR DESCRIPTION
This both implements an initial onboarding/virtual office section to the handbook and also finalizes the information on voicemail:

- closes https://github.com/hyphacoop/organizing/issues/75
- closes https://github.com/hyphacoop/handbook/issues/12