### PR TITLE
Prepare to separate repo README and gitbook cover page

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,4 +1,7 @@
 {
+  "structure": {
+    "readme": "README.md"
+  },
   "plugins": [
     "anchors"
   ]


### PR DESCRIPTION
This will allow us to have "technologies used" and other technical stuff in the readme, but not worry about it showing on the front page of our GitHub Pages handbook :)

See: https://gitbookio.gitbooks.io/documentation/format/introduction.html