### PR TITLE
Add initial about page and split readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,33 @@
 # Handbook
 
-Hypha Organizational Handbook (H₂O) describes the vision, processes, and culture of Hypha Worker Co-operative. 🌿🍄
+Hypha Organizational Handbook (H₂O) describes the vision, processes, and culture 
+of Hypha Worker Co-operative. 🌿🍄
 
-### About This Handbook
-<!-- Derived from: https://handbook.enspiral.com/#about-this-handbook -->
-
-This Handbook's primary audience is Hypha member-owners and
-collaborators, but it will be publicly available for others who
-might find it useful. The goal is to provide as much clarity and
-context as possible, while sharing our structures and practices with the
-outside world as well.
+This Handbook's primary audience is Hypha member-owners and collaborators, but 
+it will be publicly available for others who might find it useful. 
 
 ![Old-timey web 1.0 UNDER CONSTRUCTION banner](images/under-construction.gif)<br />
-This resource is in perpetual beta and constantly changing. If you
-see something that could be improved, consider this your invitation to improve
-it!
-
-## Mission and Vision
-
-*Hypha Worker Co-operative* cultivates collective growth and meaningful livelihoods through learning and building technologies together.
-
-Working in solidarity with our neighbours, we support each other and provide safe harbour to imagine and create alternative futures.
-
----
+This resource is in perpetual beta and constantly changing. If you see something 
+that could be improved, consider this your invitation to improve it!
 
 ## 🛠 Technologies Used
 
 - [**Gitbook.**][gitbook] A command line tool to help build documentation.
-- [**Node.js**][node] and [**npm**][npm]. A programming language and package manager.
-- [**CircleCI.**][circleci] A script-running service that deploys the handbook website for us in the cloud.
+- [**Node.js**][node] and [**npm**][npm]. A programming language and package 
+  manager.
+- [**CircleCI.**][circleci] A script-running service that deploys the handbook 
+  website for us in the cloud.
 
 ## 💻 Local Development
 
-To submit changes, add content, and make improvements to this handbook you can use [GitHub][repo]: [github.com/hyphacoop/handbook][repo].
+To submit changes, add content, and make improvements to this handbook you can 
+use [GitHub][repo]: [github.com/hyphacoop/handbook][repo].
 
-To edit locally, you will have to install [GitBook][gitbook] (currently deprecated), and [Node.js][node] (v4.0.0 or above) on your system.
+To edit locally, you will have to install [GitBook][gitbook] (currently 
+deprecated), and [Node.js][node] (v4.0.0 or above) on your system.
 
-It is easiest to install `gitbook-cli` with [npm][npm], the Node.js package manager. From your terminal, run the following command:
+It is easiest to install `gitbook-cli` with [npm][npm], the Node.js package 
+manager. From your terminal, run the following command:
 
 ```bash
 $ npm install gitbook-cli -g
@@ -48,11 +39,13 @@ You can preview any changes you make by running a local GitBook server:
 $ gitbook serve
 ```
 
-After starting the server, visit `http://localhost:4000` (or the address indicated by the `gitbook serve` command) in a web browser.
+After starting the server, visit `http://localhost:4000` (or the address 
+indicated by the `gitbook serve` command) in a web browser.
 
 ## Deployment
 
-The handbook is automatically built and deployed using [CircleCI][circleci] after a Pull Request is merged into master on [GitHub][repo].
+The handbook is automatically built and deployed using [CircleCI][circleci] 
+after a Pull Request is merged into master on [GitHub][repo].
 
 
 <!-- Links -->

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,8 +1,8 @@
 # Summary
 
-* [Handbook](README.md)
-* [Mission and Vision](README.md#mission-and-vision)
-  - [Values](values.md)
+* [Hypha Worker Co-operative](co-operative.md)
+  - [About Us](co-operative.md#about-us)
+  - [Mission, Vision and Values](vision.md)
 * [Our Virtual Office](onboarding.md)
   - [Onboarding](onboarding.md)
   - [Coordination 🚧](coordination.md)

--- a/book.json
+++ b/book.json
@@ -1,6 +1,6 @@
 {
   "structure": {
-    "readme": "README.md"
+    "readme": "handbook.md"
   },
   "plugins": [
     "anchors"

--- a/co-operative.md
+++ b/co-operative.md
@@ -30,7 +30,7 @@ A **member-owner**:
       - Inactive members can request to become active at any time
 
 An **employee**: 
-  - Is “someone who performs work for an employer for wages,” meeting the 
+  - Is "someone who performs work for an employer for wages," meeting the 
     [*Employment Standards Act, 2000*][es-act] [definition of employee][esa-employee] 
   - Is considered *permanent* if they:
     - Have completed a probationary period of one year 

--- a/co-operative.md
+++ b/co-operative.md
@@ -10,7 +10,7 @@ Hypha is incorporated as a **non-share capital** worker co-operative under the
 conditions on our primary object, size, and role of members, as addressed in 
 Article [1], [1.1], [144] and [145.1] of the Act.
 
-We are a non-profit organization. 
+We are a non-profit _organization_. As per 2017's [_Cutting Unnecessary Red Tape Act_](https://www.ontario.ca/laws/statute/s17020), Hypha falls under neither the current [_Corporations Act_](https://www.ontario.ca/laws/statute/90c38), nor the upcoming [_Not-for-Profit Corporations Act_](https://www.ontario.ca/laws/statute/10n15), which both govern not-for-profit _corporations_ in Ontario.
 
 ## Member-owners and Employees
 

--- a/co-operative.md
+++ b/co-operative.md
@@ -1,0 +1,50 @@
+# Hypha Worker Co-operative
+
+## About Us 
+
+Hypha Worker Co-operative Inc. is a worker co-operative incorporated on August 
+1, 2019 in Ontario, Canada (Ontario Corporation No. 5019866).
+
+Hypha is incorporated as a **non-share capital** worker co-operative under the 
+[*Ontario Co-operative Corporations Act, 1990*][coop-act]. This entails specific 
+conditions on our primary object, size, and role of members, as addressed in 
+Article [1], [1.1], [144] and [145.1] of the Act.
+
+We are a non-profit organization. 
+
+## Member-owners and Employees
+
+Every **member-owner** is both an employee and co-owner of Hypha. There are 
+seven member-owners, all of which are founding employees, with four Directors.
+
+A **member-owner**:
+  - Has completed a membership application (and/or been officially welcomed into 
+    the membership)
+  - Is a *permanent* or *founding* employee
+  - Is considered 
+    - *active* if they are in good standing with their membership fees and have 
+      not requested to change their status
+    - *inactive* if they have requested to change their status
+      - Inactive members are unable to vote, serve as a director, participate in 
+        projects, or work as an employee for so long as they remain so
+      - Inactive members can request to become active at any time
+
+An **employee**: 
+  - Is “someone who performs work for an employer for wages,” meeting the 
+    [*Employment Standards Act, 2000*][es-act] [definition of employee][esa-employee] 
+  - Is considered *permanent* if they:
+    - Have completed a probationary period of one year 
+    - Are not working under contract
+
+A **contractor**:
+  - Provides services clearly specified in a time-limited contractor agreement
+
+A **collaborator**:
+  - Participates in open Hypha activities and projects without a formal 
+    relationship
+
+
+<!-- Links -->
+[coop-act]: https://www.ontario.ca/laws/statute/90c35
+[es-act]: https://www.ontario.ca/laws/statute/00e41
+[esa-employee]: https://www.ontario.ca/document/changing-workplaces-review-final-report/chapter-8-who-employer-and-who-employee-under-employment-standards-act-2000#section-1

--- a/co-operative.md
+++ b/co-operative.md
@@ -21,7 +21,7 @@ A **member-owner**:
   - Has completed a membership application (and/or been officially welcomed into 
     the membership)
   - Is a *permanent* or *founding* employee
-  - Is considered 
+  - Is considered:
     - *active* if they are in good standing with their membership fees and have 
       not requested to change their status
     - *inactive* if they have requested to change their status

--- a/co-operative.md
+++ b/co-operative.md
@@ -7,7 +7,7 @@ Hypha Worker Co-operative Inc. is a worker co-operative incorporated on August
 
 Hypha is incorporated as a **non-share capital** worker co-operative under the 
 [*Ontario Co-operative Corporations Act, 1990*][coop-act]. This entails specific 
-conditions on our primary object, size, and role of members, as addressed in 
+conditions on our primary object, size of membership, and role of members, as addressed in 
 Article [1], [1.1], [144] and [145.1] of the Act.
 
 We are a non-profit _organization_. As per 2017's [_Cutting Unnecessary Red Tape Act_](https://www.ontario.ca/laws/statute/s17020), Hypha falls under neither the current [_Corporations Act_](https://www.ontario.ca/laws/statute/90c38), nor the upcoming [_Not-for-Profit Corporations Act_](https://www.ontario.ca/laws/statute/10n15), which both govern not-for-profit _corporations_ in Ontario.

--- a/handbook.md
+++ b/handbook.md
@@ -1,0 +1,16 @@
+# Hypha Organizational Handbook
+
+Hypha Organizational Handbook (H₂O) describes the vision, processes, and culture 
+of Hypha Worker Co-operative. 🌿🍄
+
+## About This Handbook
+<!-- Derived from: https://handbook.enspiral.com/#about-this-handbook -->
+
+This Handbook's primary audience is Hypha member-owners and collaborators, but 
+it will be publicly available for others who might find it useful. The goal is 
+to provide as much clarity and context as possible, while sharing our structures 
+and practices with the outside world as well.
+
+![Old-timey web 1.0 UNDER CONSTRUCTION banner](images/under-construction.gif)<br />
+This resource is in perpetual beta and constantly changing. If you see something 
+that could be improved, consider this your invitation to improve it!

--- a/onboarding.md
+++ b/onboarding.md
@@ -11,12 +11,6 @@ We have the following communication and contact methods:
 - 🔗 [hypha.coop](https://hypha.coop)
 - 📧 hello@hypha.coop
 
-## Organizational Structure
-
-Hypha Worker Co-operative Inc. is a worker co-operative incorporated in Ontario, Canada.
-The business has seven Founding Members, of which four Directors have signing authority.
-As a non-share-capital worker co-operative, we are a non-profit organization, and every Member is both an employee and co-owner of the business.
-
 ## Our Virtual Office
 
 In place of a physical place we have virtual office comprised of the following spaces:

--- a/vision.md
+++ b/vision.md
@@ -2,7 +2,7 @@
 
 ## Mission and Vision
 
-*Hypha Worker Co-operative* cultivates collective growth and meaningful livelihoods through learning and building technologies together.
+Hypha Worker Co-operative cultivates collective growth and meaningful livelihoods through learning and building technologies together.
 
 Working in solidarity with our neighbours, we support each other and provide safe harbour to imagine and create alternative futures.
 

--- a/vision.md
+++ b/vision.md
@@ -1,4 +1,12 @@
-# Values
+# Our Vision
+
+## Mission and Vision
+
+*Hypha Worker Co-operative* cultivates collective growth and meaningful livelihoods through learning and building technologies together.
+
+Working in solidarity with our neighbours, we support each other and provide safe harbour to imagine and create alternative futures.
+
+## Values
 
 During our 2019 retreat we [co-drafted a long list of values](https://github.com/hyphacoop/december-retreat/blob/master/2018-retreat/2018-12-04-retreat-day-01.md#finding-value-alignment), consensing that the list has broad alignment to those of the participants of this co-operative.
 


### PR DESCRIPTION
A few small changes to set us up for various other todos.

This builds on #34 and breaks off a micro aspect of #22 and our business plan in order to create a new "about Hyhpa" section. I imagine this will be where our final "one page" summary of our organization (see: https://github.com/hyphacoop/organizing/issues/155) will live.