### PR TITLE
Clarifying "Finance" section as working through payroll

### DIFF
--- a/finance.md
+++ b/finance.md
@@ -74,7 +74,7 @@ Hypha has the following [_program accounts_][program-accounts] with the Canada R
 - :soon: `RP0001` **Payroll Deduction (RP)** is reported and paid each pay period
 - :soon: `RT0001` **GST/HST (RT)** is [reported and paid][sales-tax-how] each filing period (TBD)
 
-   [sales-tax-about]: https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/gst-hst-businesses/account-register.html#once
+   [sales-tax-how]: https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/gst-hst-businesses/account-register.html#once
 
 As a non-profit organization, our co-operative should have tax-exempt status and pay no corporate income tax.
 

--- a/finance.md
+++ b/finance.md
@@ -66,7 +66,7 @@ The exact percentage is the same across all projects during a period and can be 
 
 ### Reporting & Remitting Taxes
 
-Hypha has the following [_program accounts_][program-accounts] with the Canada Revenue Agency (CRA):
+Hypha has the following [program accounts][program-accounts] with the Canada Revenue Agency (CRA):
 
    [program-accounts]: https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/changes-your-business/adding-accounts-your-business-number-bn.html
 

--- a/finance.md
+++ b/finance.md
@@ -66,10 +66,15 @@ The exact percentage is the same across all projects during a period and can be 
 
 ### Reporting & Remitting Taxes
 
-Hypha has the following _program accounts_ with the Canada Revenue Agency (CRA):
+Hypha has the following [_program accounts_][program-accounts] with the Canada Revenue Agency (CRA):
 
-- **Corporate Income Tax (RC)** is reported and remitted each tax year
-- **Payroll Deduction (RP)** is reported and remitted each pay period
+   [program-accounts]: https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/changes-your-business/adding-accounts-your-business-number-bn.html
+
+- :ballot_box_with_check: `RC0001` **Corporate Income Tax (RC)** is filed/reported and remitted/paid each tax year
+- :soon: `RP0001` **Payroll Deduction (RP)** is reported and paid each pay period
+- :soon: `RT0001` **GST/HST (RT)** is [reported and paid][sales-tax-how] each filing period (TBD)
+
+   [sales-tax-about]: https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/gst-hst-businesses/account-register.html#once
 
 As a non-profit organization, our co-operative should have tax-exempt status and pay no corporate income tax.
 

--- a/finance.md
+++ b/finance.md
@@ -71,7 +71,7 @@ Hypha has the following [_program accounts_][program-accounts] with the Canada R
    [program-accounts]: https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/changes-your-business/adding-accounts-your-business-number-bn.html
 
 - :ballot_box_with_check: `RC0001` **Corporate Income Tax (RC)** is filed/reported and remitted/paid each tax year
-- :soon: `RP0001` **Payroll Deduction (RP)** is reported and paid each pay period
+- :ballot_box_with_check: `RP0001` **Payroll Deduction (RP)** is reported and paid each pay period
 - :soon: `RT0001` **GST/HST (RT)** is [reported and paid][sales-tax-how] each filing period (TBD)
 
    [sales-tax-how]: https://www.canada.ca/en/revenue-agency/services/tax/businesses/topics/gst-hst-businesses/account-register.html#once


### PR DESCRIPTION
Re-ticketed from https://github.com/hyphacoop/organizing/issues/156

### CRA Progam Accounts

Seems we only have one program account right now. Cleared that up in doc. Can update as we register for more.

Also, added the numbers of the accounts.

Lastly, small change to better hat-tip to the official language of _filing_ and _remitting_ that's on the CRA website (h/t @dcwalk) but also plain language human-speak counterparts of _reporting_ and _paying_.