### PR TITLE
Add guide for updating labels

### DIFF
--- a/guides.md
+++ b/guides.md
@@ -29,7 +29,7 @@ our values.
 
 ## Issue Labels
 
-We have specific repos (known as _synced repos_ throughout this guide) configured to mirror all labels from the root `hyphacoop/organizing`,
+We have specific GitHub repos (known as _synced repos_ throughout this guide) configured to mirror all labels from the root `hyphacoop/organizing`,
 on each change to the root repo's labels.
 Though some of the below steps are more complicated than we'd ideally like,
 this is because the automation is cautious and won't delete _any_ in-use labels (regardless of open/closed state),

--- a/guides.md
+++ b/guides.md
@@ -47,8 +47,8 @@ and it will be added to others within a few minutes.
 To **delete an existing label**, search for the label you'd like to delete,
 [like so](https://github.com/issues?q=org:hyphacoop+label:doomed-label).
 Our automation is cautious, and so will only delete labels from repos where it's _NOT in use_.
-For any repos represented search results, delete the label from that repo.
-Once not labelled issues show up, delete the label from `hyphacoop/organizing`,
+For any repos represented in the search results, delete the label from that repo.
+Once no labelled issues show up, delete the label from `hyphacoop/organizing`,
 and anything else will be cleaned up. If you leave any issues labelled,
 the automation will simply do cleanup on its next run.
 As soon as a label is unused in a repo, the automation will remove it on the next run.

--- a/guides.md
+++ b/guides.md
@@ -31,15 +31,40 @@ our values.
 
 ## Managing Labels
 
-We have _synced repos_ configured that mirror all labels from the root `hyphacoop/organizing`, on each change to the root repo's labels. Though some of the below steps are more complicated than we'd ideally like, this is because the automation is cautious and won't delete in-use labels, so _nothing destructive will happen_.
+We have _synced repos_ configured that mirror all labels from the root `hyphacoop/organizing`,
+on each change to the root repo's labels.
+Though some of the below steps are more complicated than we'd ideally like,
+this is because the automation is cautious and won't delete in-use labels,
+so _nothing destructive will happen_.
 
-To **manage the list of _synced repos_** (e.g., ensuring a new repo starts having labels synced), add a new entry to `LABEL_REPO_TARGETS` in [this configuration file](https://github.com/hyphacoop/organizing/blob/master/.github/workflows/sync-labels.yml#L24)
+To **manage the list of _synced repos_** (e.g., ensuring a new repo starts having labels synced),
+add a new entry to `LABEL_REPO_TARGETS` in [this configuration file](https://github.com/hyphacoop/organizing/blob/master/.github/workflows/sync-labels.yml#L24)
 
-To **create a new label**, just add it to the `hyphacoop/organizing` repo, and it will be added to others within a few minutes. (Sync events are [logged in this issue as new comments](https://github.com/hyphacoop/organizing/issues/145) for troubleshooting.)
+To **create a new label**, just add it to the `hyphacoop/organizing` repo,
+and it will be added to others within a few minutes.
+(Sync events are [logged in this issue as new comments](https://github.com/hyphacoop/organizing/issues/145) for troubleshooting.)
 
-To **delete an existing label**, search for the label you'd like to delete, [like so](https://github.com/issues?q=org:hyphacoop+label:doomed-label). Our automation is cautious, and so will only delete labels from repos where it's _NOT in use_. For any repos represented search results, delete the label from that repo. Once not labelled issues show up, delete the label from `hyphacoop/organizing`, and anything else will be cleaned up. If you leave any issues labelled, the automation will simply do cleanup on its next run. As soon as a label is unused in a repo, the automation will remove it on the next run.
+To **delete an existing label**, search for the label you'd like to delete,
+[like so](https://github.com/issues?q=org:hyphacoop+label:doomed-label).
+Our automation is cautious, and so will only delete labels from repos where it's _NOT in use_.
+For any repos represented search results, delete the label from that repo.
+Once not labelled issues show up, delete the label from `hyphacoop/organizing`,
+and anything else will be cleaned up. If you leave any issues labelled,
+the automation will simply do cleanup on its next run.
+As soon as a label is unused in a repo, the automation will remove it on the next run.
 
-To **rename an existing label** (this one's a bit tricky), search for the label you'd like to rename, [like so](https://github.com/issues?q=org:hyphacoop+label:wg:finance). Ignore `hyphacoop/organizing` for now, we'll save it for last. For every other repo where it's used, click the "repo" link, and visit the label page to manually rename. Lastly, rename the label in `hyphacoop/organizing`, and it will ensure the label is removed in any repos where it wasn't in-use. (Renaming is understood by the automation as a newly created label and a deleted label.)
+To **rename an existing label** (this one's a bit tricky),
+search for the label you'd like to rename,
+[like so](https://github.com/issues?q=org:hyphacoop+label:wg:finance).
+Ignore `hyphacoop/organizing` for now, we'll save it for last.
+For every other repo where it's used, click the "repo" link,
+and visit the label page to manually rename.
+Lastly, rename the label in `hyphacoop/organizing`,
+and it will ensure the label is removed in any repos where it wasn't in-use.
+(Renaming is understood by the automation as a newly created label and a deleted label.)
+
+To **force a label sync**, assuming you're impatient for it to do clean-up of unsued labels,
+slightly change a _description_ or _color_ of a label in `hyphacoop/organizing`.
 
 ## Invoices
 

--- a/guides.md
+++ b/guides.md
@@ -17,8 +17,8 @@ our values.
 
 ### Contents
 
-- [GitHub](#github)
 - [Invoices](#invoices)
+- [Issue Labels](#issue-labels)
 - [Meetings](#meetings)
 - [Projects](#projects)
 - [Sensitive Data](#sensitive-data)

--- a/guides.md
+++ b/guides.md
@@ -31,10 +31,10 @@ our values.
 
 ## Managing Labels
 
-We have _synced repos_ configured that mirror all labels from the root `hyphacoop/organizing`,
+We have specific repos (known as _synced repos_ throughout this guide) configured to mirror all labels from the root `hyphacoop/organizing`,
 on each change to the root repo's labels.
 Though some of the below steps are more complicated than we'd ideally like,
-this is because the automation is cautious and won't delete in-use labels,
+this is because the automation is cautious and won't delete _any_ in-use labels (regardless of open/closed state),
 so _nothing destructive will happen_.
 
 To **manage the list of _synced repos_** (e.g., ensuring a new repo starts having labels synced),

--- a/guides.md
+++ b/guides.md
@@ -17,6 +17,7 @@ our values.
 
 ### Contents
 
+- [GitHub](#github)
 - [Invoices](#invoices)
 - [Meetings](#meetings)
 - [Projects](#projects)
@@ -25,6 +26,20 @@ our values.
 - [Timesheets](#timesheets)
 - [Voicemail](#voicemail)
 - [References](#references)
+
+## GitHub
+
+## Managing Labels
+
+We have _synced repos_ configured that mirror all labels from the root `hyphacoop/organizing`, on each change to the root repo's labels. Though some of the below steps are more complicated than we'd ideally like, this is because the automation is cautious and won't delete in-use labels, so _nothing destructive will happen_.
+
+To **manage the list of _synced repos_** (e.g., ensuring a new repo starts having labels synced), add a new entry to `LABEL_REPO_TARGETS` in [this configuration file](https://github.com/hyphacoop/organizing/blob/master/.github/workflows/sync-labels.yml#L24)
+
+To **create a new label**, just add it to the `hyphacoop/organizing` repo, and it will be added to others within a few minutes. (Sync events are [logged in this issue as new comments](https://github.com/hyphacoop/organizing/issues/145) for troubleshooting.)
+
+To **delete an existing label**, search for the label you'd like to delete, [like so](https://github.com/issues?q=org:hyphacoop+label:doomed-label). Our automation is cautious, and so will only delete labels from repos where it's _NOT in use_. For any repos represented search results, delete the label from that repo. Once not labelled issues show up, delete the label from `hyphacoop/organizing`, and anything else will be cleaned up. If you leave any issues labelled, the automation will simply do cleanup on its next run. As soon as a label is unused in a repo, the automation will remove it on the next run.
+
+To **rename an existing label** (this one's a bit tricky), search for the label you'd like to rename, [like so](https://github.com/issues?q=org:hyphacoop+label:wg:finance). Ignore `hyphacoop/organizing` for now, we'll save it for last. For every other repo where it's used, click the "repo" link, and visit the label page to manually rename. Lastly, rename the label in `hyphacoop/organizing`, and it will ensure the label is removed in any repos where it wasn't in-use. (Renaming is understood by the automation as a newly created label and a deleted label.)
 
 ## Invoices
 

--- a/guides.md
+++ b/guides.md
@@ -27,9 +27,7 @@ our values.
 - [Voicemail](#voicemail)
 - [References](#references)
 
-## GitHub
-
-## Managing Labels
+## Issue Labels
 
 We have specific repos (known as _synced repos_ throughout this guide) configured to mirror all labels from the root `hyphacoop/organizing`,
 on each change to the root repo's labels.

--- a/guides.md
+++ b/guides.md
@@ -27,43 +27,6 @@ our values.
 - [Voicemail](#voicemail)
 - [References](#references)
 
-## Issue Labels
-
-We have specific GitHub repos (known as _synced repos_ throughout this guide) configured to mirror all labels from the root `hyphacoop/organizing`,
-on each change to the root repo's labels.
-Though some of the below steps are more complicated than we'd ideally like,
-this is because the automation is cautious and won't delete _any_ in-use labels (regardless of open/closed state),
-so _nothing destructive will happen_.
-
-To **manage the list of _synced repos_** (e.g., ensuring a new repo starts having labels synced),
-add a new entry to `LABEL_REPO_TARGETS` in [this configuration file](https://github.com/hyphacoop/organizing/blob/master/.github/workflows/sync-labels.yml#L24)
-
-To **create a new label**, just add it to the `hyphacoop/organizing` repo,
-and it will be added to others within a few minutes.
-(Sync events are [logged in this issue as new comments](https://github.com/hyphacoop/organizing/issues/145) for troubleshooting.)
-
-To **delete an existing label**, search for the label you'd like to delete,
-[like so](https://github.com/issues?q=org:hyphacoop+label:doomed-label).
-Our automation is cautious, and so will only delete labels from repos where it's _NOT in use_.
-For any repos represented in the search results, delete the label from that repo.
-Once no labelled issues show up, delete the label from `hyphacoop/organizing`,
-and anything else will be cleaned up. If you leave any issues labelled,
-the automation will simply do cleanup on its next run.
-As soon as a label is unused in a repo, the automation will remove it on the next run.
-
-To **rename an existing label** (this one's a bit tricky),
-search for the label you'd like to rename,
-[like so](https://github.com/issues?q=org:hyphacoop+label:wg:finance).
-Ignore `hyphacoop/organizing` for now, we'll save it for last.
-For every other repo where it's used, click the "repo" link,
-and visit the label page to manually rename.
-Lastly, rename the label in `hyphacoop/organizing`,
-and it will ensure the label is removed in any repos where it wasn't in-use.
-(Renaming is understood by the automation as a newly created label and a deleted label.)
-
-To **force a label sync**, assuming you're impatient for it to do clean-up of unsued labels,
-slightly change a _description_ or _color_ of a label in `hyphacoop/organizing`.
-
 ## Invoices
 
 Prior to creating an invoice, confirm with the client whether they would like to pay in CAD, USD, EUR, or GBP, and in what country their financial institution is based, then proceed with the following steps.
@@ -203,6 +166,43 @@ The following example shows how to do that in a single transaction from Transfer
     1. If there is a discrepancy, click the `Resolve` button and change `CATEGORY` to `Bank charges`, then click `Save`.
 
 1. Archive the PDF of the paid and finalized invoice in our [shared drive](https://link.hypha.coop/drive) under the `Invoices` directory with filename `xxxx-project.pdf`, where `xxxx` is the invoice number (e.g. `1001-aether.pdf`).
+
+## Issue Labels
+
+We have specific GitHub repos (known as _synced repos_ throughout this guide) configured to mirror all labels from the root `hyphacoop/organizing`,
+on each change to the root repo's labels.
+Though some of the below steps are more complicated than we'd ideally like,
+this is because the automation is cautious and won't delete _any_ in-use labels (regardless of open/closed state),
+so _nothing destructive will happen_.
+
+To **manage the list of _synced repos_** (e.g., ensuring a new repo starts having labels synced),
+add a new entry to `LABEL_REPO_TARGETS` in [this configuration file](https://github.com/hyphacoop/organizing/blob/master/.github/workflows/sync-labels.yml#L24)
+
+To **create a new label**, just add it to the `hyphacoop/organizing` repo,
+and it will be added to others within a few minutes.
+(Sync events are [logged in this issue as new comments](https://github.com/hyphacoop/organizing/issues/145) for troubleshooting.)
+
+To **delete an existing label**, search for the label you'd like to delete,
+[like so](https://github.com/issues?q=org:hyphacoop+label:doomed-label).
+Our automation is cautious, and so will only delete labels from repos where it's _NOT in use_.
+For any repos represented in the search results, delete the label from that repo.
+Once no labelled issues show up, delete the label from `hyphacoop/organizing`,
+and anything else will be cleaned up. If you leave any issues labelled,
+the automation will simply do cleanup on its next run.
+As soon as a label is unused in a repo, the automation will remove it on the next run.
+
+To **rename an existing label** (this one's a bit tricky),
+search for the label you'd like to rename,
+[like so](https://github.com/issues?q=org:hyphacoop+label:wg:finance).
+Ignore `hyphacoop/organizing` for now, we'll save it for last.
+For every other repo where it's used, click the "repo" link,
+and visit the label page to manually rename.
+Lastly, rename the label in `hyphacoop/organizing`,
+and it will ensure the label is removed in any repos where it wasn't in-use.
+(Renaming is understood by the automation as a newly created label and a deleted label.)
+
+To **force a label sync**, assuming you're impatient for it to do clean-up of unsued labels,
+slightly change a _description_ or _color_ of a label in `hyphacoop/organizing`.
 
 ## Meetings
 


### PR DESCRIPTION
Re-ticketed from https://github.com/hyphacoop/handbook/pull/56

Frankly, I'm not enamoured to this label-update strategy, now that I've been forced to write it down :) The one thing it has going for it is that it's **very quick and easy to add new labels everywhere**, and to **expand the definition of "everywhere"** to new repos. But when it comes to renaming, it's a bit awkward.

A perk though (of only in-use labels sticking around) is that this makes the cleanup/managment auditable via search, if that makes sense -- if the label isn't showing up in search, then it's been cleaned up... which is a nice assurance. Normally, a label that's sneaking around unused is hard to find without clicking through a bunch of repos.