### PR TITLE
replaced Mailcow example

### DIFF
--- a/guides.md
+++ b/guides.md
@@ -759,7 +759,7 @@ our [`shortlinks` repo](https://github.com/hyphacoop/shortlinks).
 ### Accessing shortlinks
 
 > **Hint:** You can use a URL hash to deep-link into an expanded shortlink.
-> Example:&nbsp;http://link.hypha.coop/inventory#MailCow
+> Example:&nbsp;http://link.hypha.coop/inventory#LinkedIn
 
 Shortlinks work on their own in the address bar, but for even easier access on your own
 workstation, you can **add a "custom search engine" keyword to your


### PR DESCRIPTION
Mailcow title was changed in inventory and no longer worked. 
Replaced with linked in example.