### PR TITLE
Add 7 coop principles to handbook

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -4,6 +4,7 @@
   - [About Us](co-operative.md#about-us)
   - [Look and Feel](look-and-feel.md)
   - [Mission, Vision and Values](vision.md)
+  - [Co-operative Principles](co-operative-principles.md)
   - [Objectives and Key Results (OKRs)](okrs.md)
   - [Working Groups](working-groups.md)
 * [Our Virtual Office](onboarding.md)

--- a/co-operative-principles.md
+++ b/co-operative-principles.md
@@ -1,0 +1,51 @@
+# Co-operative Principles
+
+The updated 1995 [International Cooperative Association][ica-identity] 
+Statement on the Cooperative Identity have a definition of a cooperative, 
+the values of cooperatives, and the seven cooperative principles. 
+These principles serve as the guidelines by which cooperatives put their values into practice.
+
+## Co-operative Values 
+
+Cooperatives are based on the values of self-help, self-responsibility, 
+democracy, equality, equity, and solidarity. In the tradition of their founders, 
+cooperative members believe in the ethical values of honesty, openness, 
+social responsibility and caring for others.
+
+## Seven Principles 
+
+1. **Voluntary and Open Membership**  
+  Cooperatives are voluntary organisations, 
+  open to all persons able to use their services and willing to accept the responsibilities of membership, 
+  without gender, social, racial, political or religious discrimination.
+2. **Democratic Member Control**  
+  Cooperatives are democratic organisations controlled by their members, 
+  who actively participate in setting their policies and making decisions. 
+  Men and women serving as elected representatives are accountable to the membership. 
+  In primary cooperatives members have equal voting rights (one member, one vote) 
+  and cooperatives at other levels are also organised in a democratic manner.
+3. **Member Economic Participation**  
+  Members contribute equitably to, and democratically control, the capital of their cooperative. 
+  At least part of that capital is usually the common property of the cooperative. 
+  Members usually receive limited compensation, if any, on capital subscribed as a condition of membership. 
+  Members allocate surpluses for any or all of the following purposes: developing their cooperative, 
+  possibly by setting up reserves, part of which at least would be indivisible; 
+  benefiting members in proportion to their transactions with the cooperative; 
+  and supporting other activities approved by the membership.
+4. **Autonomy and Independence**  
+  Cooperatives are autonomous, self-help organisations controlled by their members. 
+  If they enter into agreements with other organisations, including governments, 
+  or raise capital from external sources, 
+  they do so on terms that ensure democratic control by their members and maintain their cooperative autonomy.
+5. **Education, Training, and Information**  
+  Cooperatives provide education and training for their members, elected representatives, 
+  managers, and employees so they can contribute effectively to the development of their co-operatives. 
+  They inform the general public - particularly young people and opinion leaders - about the nature and benefits of co-operation.
+6. **Cooperation among Cooperatives**  
+  Cooperatives serve their members most effectively and strengthen the cooperative movement by working together through local, 
+  national, regional and international structures.
+7. **Concern for Community**  
+  Cooperatives work for the sustainable development of their communities through policies approved by their members.
+
+<!-- Links -->
+[ica-identity]: https://www.ica.coop/en/cooperatives/cooperative-identity


### PR DESCRIPTION
We had these referenced in the business plan, and linked/pointed out the relevant principle alongside. Figured we could move that practice into the handbook.