### PR TITLE
Don't use patcon as committer during deploy

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -25,8 +25,7 @@ jobs:
         ./node_modules/.bin/gitbook build
 
     - name: Deploy
-      uses: peaceiris/actions-gh-pages@v2
-      env:
-        PERSONAL_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
-        PUBLISH_BRANCH: gh-pages
-        PUBLISH_DIR: ./_book
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./_book


### PR DESCRIPTION
Migrate to action peaceiris/actions-gh-pages@v3. Switch from patcon's personal access token to ephemeral token auto-generated for each workflow run.

This will not use hyphacoop-bot, but also will not ever break, and is more secure. Not sure who the committer will be, but I think it will show up as "GitHub Action" bot.