### PR TITLE
Fix build by removing private Loomio link

### DIFF
--- a/co-operative.md
+++ b/co-operative.md
@@ -91,8 +91,7 @@ A summary is provided below:
 
 ## Notes
 
-<sup>1. A full list of [CWCF affiliations](https://canadianworker.coop/about/affliations/) is on their website. We have a [list of public communication spaces 🔒](https://loomio.hypha.coop/d/sWnNveKO/public-communication-spaces), 
-along with places we have a presence as a co-operative on our Loomio.</sup>
+<sup>1. A full list of [CWCF affiliations](https://canadianworker.coop/about/affliations/) is on their website.</sup>
 
 
 <!-- Links -->


### PR DESCRIPTION
Probably new version of Loomio has diff http code.

```
Checking 242 external links...
- ./_book/co-operative.html
Ran on 21 files!

  - External link https://loomio.hypha.coop/d/sWnNveKO/public-communication-spaces failed: 403 No error
```