### PR TITLE
Move htmlproofer command run by CI into Makefile

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -42,9 +42,4 @@ jobs:
         bundle install
 
     - name: Test the HTML
-      run: |
-        bundle exec htmlproofer ./_book \
-          --allow-hash-href \
-          --check-html \
-          --empty-alt-ignore \
-          --url-ignore "/github.com\/hyphacoop\/organizing-private/,/github.com\/issues/"
+      run: make check

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+RUN = bundle exec
+
+check: ## Check HTML and links
+	$(RUN) htmlproofer ./_book \
+			--allow-hash-href \
+			--check-html \
+			--url-ignore "/github.com\/hyphacoop\/organizing-private/,/github.com\/issues/"
+
+%:
+	@true
+
+.PHONY: help
+
+help:
+	@echo 'Usage: make <command>'
+	@echo
+	@echo 'where <command> is one of the following:'
+	@echo
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+.DEFAULT_GOAL := help


### PR DESCRIPTION
Just makes it easier to run locally. Helper text when running `make` without args:

<img width="547" alt="Screen Shot 2021-02-12 at 1 30 23 PM" src="https://user-images.githubusercontent.com/305339/107807752-95928080-6d36-11eb-9e34-ff14f1cb7ee1.png">
