### PR TITLE
Extended connection timeout on link checker from 10 to 30s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
+# Max seconds for both full http request and connection phase of link checker.
+TIMEOUT = 30
 RUN = bundle exec
 
 check: ## Check HTML and links
 	$(RUN) htmlproofer ./_book \
 			--allow-hash-href \
 			--check-html \
+			--typhoeus-config '{ "timeout": $(TIMEOUT), "connecttimeout": $(TIMEOUT) }' \
 			--url-ignore "/github.com\/hyphacoop\/organizing-private/,/github.com\/issues/"
 
 %:


### PR DESCRIPTION
Re-ticketed from https://github.com/hyphacoop/handbook/pull/110#issuecomment-778553269