### PR TITLE
Restructure onboarding and offboarding / active and inactive

### DIFF
--- a/guides.md
+++ b/guides.md
@@ -20,8 +20,10 @@ our values.
 - [Calendar](#calendar)
 - [Email](#email)
 - [Expense Reimbursement](#expense-reimbursement)
+- [Hiring](#hiring)
 - [Invoices](#invoices)
 - [Issue Labels](#issue-labels)
+- [Inactivating Membership](#inactivating-membership)
 - [Meetings](#meetings)
 - [Payroll](#payroll)
 - [Projects](#projects)
@@ -253,6 +255,19 @@ For the Finance WG to approve an expense:
 1. Verify that the amount shows up correctly on the `Expense Reimbursement` column on [Employee Payroll](http://link.hypha.coop/payroll) of the applicable pay period, so it gets entered into Wagepoint on the next payroll run.
 
 1. After reimbursements are paid out through Wagepoint, our bookkeeper will file the the amounts into expense accounts in [Quickbooks Online](https://quickbooks.intuit.com/ca/) based on the [Posting Journals](https://drive.google.com/drive/u/0/folders/1wWo9KqNwWdUK5d-jkApV3id_Y_dpftT9) and [Employee Expenses](https://link.hypha.coop/expenses) sheet.
+
+## Hiring 
+
+
+
+
+## Inactivating Membership
+
+When members seek to go inactive they should do the following:
+
+1. Send an email to [operations@hypha.coop](mailto:operations@hypha.coop) with notification of the change and the date you wish to become inactive and return (if known).
+
+Operations then will work with Infrastructure to update appropriate permissions and access inline with our Working Open guidelines and the offboarding checklist.
 
 ## Invoices
 

--- a/guides.md
+++ b/guides.md
@@ -499,55 +499,6 @@ members. Skip the steps below at your discretion for low-stakes topics._
   1. Use the private dial-in number from our [technical Jitsi documentation](https://github.com/hyphacoop/organizing-private/blob/master/documents/infrastructure/jitsi.md).
   2. _After_ prompt, enter conference code `307 314 3734 #`
 
-## Onboarding Checklist
-
-This is a checklist for onboarding a new Member to the Co-operative 🚀
-
-### Setting up communications
-
-1. Get Signal number and add to group.
-
-1. Get Matrix account and invite to spaces:
-  - Private chat `#hyphacoop-private:tomesh.net`
-  - Public chat `#hyphacoop-open:tomesh.net`
-  - Community `+hyphacoop:tomesh.net`
-
-1. Set up [`hypha.coop` email](https://link.hypha.coop/email):
-  - [Create new mailbox with Mailcow](#creating-new-inboxes-administrators)
-  - Set up initial forwarder
-  - Add to `members@`
-
-### Setting up virtual office
-
-1. Invite to [Passbolt](https://pass.hypha.coop):
-  - After acceptance, add to `Member-Worker` group
-  - Ensure Member understands it is their responsibility to back-up their own private key
-  - Ensure Member understands when creating a password, they need to grant access to appropriate groups (e.g., when a password is meant to be shared between Members, otherwise others do not know that password exists in Passbolt)
-
-1. Invite to [GitHub Organization](https://github.com/hyphacoop):
-  - Add to `Worker-Owner` [GitHub Team](https://link.hypha.coop/teams)
-
-1. Get Google-friendly email address:
-  - Share access to [Drive](https://link.hypha.coop/drive)
-  - Invite to calendars:
-    - https://link.hypha.coop/calendar
-    - https://link.hypha.coop/availability
-
-1. Invite to [Loomio](https://loomio.hypha.coop/).
-
-1. Share [weekly schedule](https://link.hypha.coop/schedules) (recommend without password).
-
-### Setting up employee record and payroll
-
-1. Collect information for [employee record](https://link.hypha.coop/employees).
-
-1. Add Member SIN to Passbolt and share access with `People Operations` group.
-    Change the Member access to the entry as read-only, as this information is for recording keeping and the Member should not be able to modify it.
-
-1. Collect encrypted (see [Sensitive Data](#sensitive-data) guide) [`TD1` and `TD1-ON` forms](https://www.canada.ca/en/revenue-agency/services/forms-publications/td1-personal-tax-credits-returns.html) to [Drive](https://link.hypha.coop/drive). 
-
-1. Add Member [as Employee in Wagepoint](#adding-a-new-employee) for payroll.
-
 ## Payroll
 
 This guide describes how to use our payroll service provider, [Wagepoint](https://wagepoint.com), to set up a payroll run for the pay period.

--- a/guides.md
+++ b/guides.md
@@ -23,7 +23,6 @@ our values.
 - [Invoices](#invoices)
 - [Issue Labels](#issue-labels)
 - [Meetings](#meetings)
-- [Onboarding Checklist](#onboarding-checklist)
 - [Payroll](#payroll)
 - [Projects](#projects)
 - [Sensitive Data](#sensitive-data)

--- a/guides.md
+++ b/guides.md
@@ -259,6 +259,9 @@ For the Finance WG to approve an expense:
 ## Hiring 
 
 
+### Onboarding a member 
+
+When a new member or employee is about to start their position at Hypha,  Operations will work set them up in the virtual office following the [Onboarding](./onboarding.md) materials and [checklist](./templates/checklist-onboarding.md).
 
 
 ## Inactivating Membership
@@ -267,7 +270,7 @@ When members seek to go inactive they should do the following:
 
 1. Send an email to [operations@hypha.coop](mailto:operations@hypha.coop) with notification of the change and the date you wish to become inactive and return (if known).
 
-Operations then will work with Infrastructure to update appropriate permissions and access inline with our Working Open guidelines and the offboarding checklist.
+Operations then will work with Infrastructure to update appropriate permissions and access inline with our Working Open guidelines and [offboarding checklist](./templates/checklist-offboarding.md).
 
 ## Invoices
 

--- a/onboarding.md
+++ b/onboarding.md
@@ -94,7 +94,7 @@ This is a checklist for onboarding new members, workers, and contractors to the 
 <!-- Links -->
 [link-shortener]: https://link.hypha.coop
 [service-inventory]: https://link.hypha.coop/inventory
-[accessing-em]: /guides.html#using-your-new-inbox-users
+[accessing-em]: /guides.md#using-your-new-inbox-users
 [accessing-vm]: /guides.md#accessing-voicemail
 [managing-vm]: /guides.md#managing-voicemail-and-phone-forwarding
 [matrix-chat]: https://chat.tomesh.net/#/group/+hyphacoop:tomesh.net
@@ -104,4 +104,4 @@ This is a checklist for onboarding new members, workers, and contractors to the 
 [google-drive]: https://link.hypha.coop/drive
 [bb]: https://docs.google.com/drawings/d/1tpczePR5ky0EkdOGGdfU16irDz-gjdC61p2QGoAKhIE/edit
 [bb-folder]: https://drive.google.com/drive/folders/1XN1xw_3Lm6gWEuMla3MrbuK1VW0FmABt
-[operations]: http://localhost:4000/working-groups.html#operations
+[operations]: /working-groups.md#operations

--- a/onboarding.md
+++ b/onboarding.md
@@ -62,9 +62,9 @@ This is a checklist for onboarding new members, workers, and contractors to the 
 1. Add member SIN to Passbolt and share access with `People Operations` group.
    Change the member access to the entry as read-only, as this information is for recording keeping and the Member should not be able to modify it
 
-1. Collect encrypted (see [Sensitive Data](#sensitive-data) guide) [`TD1` and `TD1-ON` forms](https://www.canada.ca/en/revenue-agency/services/forms-publications/td1-personal-tax-credits-returns.html) to [Drive](https://link.hypha.coop/drive)
+1. Collect encrypted (see [Sensitive Data](./guides.md#sensitive-data) guide) [`TD1` and `TD1-ON` forms](https://www.canada.ca/en/revenue-agency/services/forms-publications/td1-personal-tax-credits-returns.html) to [Drive](https://link.hypha.coop/drive)
 
-1. Add member to Clockify and [as Employee in Wagepoint](#adding-a-new-employee) for payroll
+1. Add member to Clockify and [as Employee in Wagepoint](./guides.md#adding-a-new-employee) for payroll
 
 #### Set up communications
 
@@ -76,10 +76,10 @@ This is a checklist for onboarding new members, workers, and contractors to the 
   - Community `+hyphacoop:tomesh.net`
 
 1. Set up a [`hypha.coop` email](https://link.hypha.coop/email) address:
-  - [Create new mailbox with Mailcow](#creating-new-inboxes-administrators)
-  - Set up forwarder (if needed)
-  - Add to `members@`
-  - Add to relevant WG forwarders
+  - Ask Infrastructure to [create new mailbox with Mailcow](./guides.md#creating-new-inboxes-administrators)
+    - Set up forwarder (if needed)
+    - Add to `members@`
+    - Add to relevant WG forwarders
 
 #### Set up virtual office
 

--- a/onboarding.md
+++ b/onboarding.md
@@ -34,23 +34,28 @@ We also have the following "helper" tools to navigate our office spaces:
 
 This is a checklist for onboarding new members, workers, and contractors to the Co-operative that should be done by the [Operations WG][operations]. 🚀
 
-### _New members will provide..._
+### _New workers and contractors will provide..._
 
+- Preferred pronouns
+- A permanent and/or mailing address
+- A personal email for communications
+- A google-friendly email address (this could be a prior personal address or a hypha email can be used once set up)
 - A [Signal](https://www.signal.org/)-friendly number 
 - A [Matrix](https://matrix.org/) account (feel free to register on the [Toronto Mesh homeserver](https://chat.tomesh.net/#/register) where Hypha rooms exist)
 - A [Github](https://github.com/) account
-- A personal email for communications
-- A google-friendly email address (this could be a prior personal address or a hypha email can be used once set up)
 - For members and workers:
-  - A permanent or mailing address
   - Their Social Insurance Number (SIN) 
   - Completed `TD1` and `TD1-ON` forms 
 
 ### _Operations will..._
 
+#### Set up contractor documents
+
+1. Prepare and provide an Independent Contractor Agreement outlining the service description, contractor relationship, including the Intellectual Property Agreement
+
 #### Set up employee documents, employee record and payroll
 
-1. Prepare and provide an Employee Acknowledgement outlining the job description, employment relationship, and Intellectual Property Agreement
+1. Prepare and provide an Employee Acknowledgement outlining the job description, employment relationship, including the Intellectual Property Agreement
 
 1. Collect information above and complete [employee record](https://link.hypha.coop/employees)
 

--- a/onboarding.md
+++ b/onboarding.md
@@ -34,7 +34,8 @@ We also have the following "helper" tools to navigate our office spaces:
 
 This is a checklist for onboarding new members, workers, and contractors to the Co-operative that should be done by the [Operations WG][operations]. 🚀
 
-**New members will provide...**:
+### _New members will provide..._
+
 - A [Signal](https://www.signal.org/)-friendly number 
 - A [Matrix](https://matrix.org/) account (feel free to register on the [Toronto Mesh homeserver](https://chat.tomesh.net/#/register) where Hypha rooms exist)
 - A [Github](https://github.com/) account
@@ -45,9 +46,11 @@ This is a checklist for onboarding new members, workers, and contractors to the 
   - Their Social Insurance Number (SIN) 
   - Completed `TD1` and `TD1-ON` forms 
 
-**Operations will...**
+### _Operations will..._
 
-### Set up employee record and payroll
+#### Set up employee documents, employee record and payroll
+
+1. Prepare and provide an Employee Acknowledgement outlining the job description, employment relationship, and Intellectual Property Agreement
 
 1. Collect information above and complete [employee record](https://link.hypha.coop/employees)
 
@@ -58,7 +61,7 @@ This is a checklist for onboarding new members, workers, and contractors to the 
 
 1. Add member [as Employee in Wagepoint](#adding-a-new-employee) for payroll
 
-### Set up communications
+#### Set up communications
 
 1. Add member to Signal `hyphacoop (Emergency Channel)` group
 
@@ -69,10 +72,11 @@ This is a checklist for onboarding new members, workers, and contractors to the 
 
 1. Set up a [`hypha.coop` email](https://link.hypha.coop/email) address:
   - [Create new mailbox with Mailcow](#creating-new-inboxes-administrators)
-  - Set up initial forwarder
+  - Set up forwarder (if needed)
   - Add to `members@`
+  - Add to relevant WG forwarders
 
-### Set up virtual office
+#### Set up virtual office
 
 1. Invite to [Passbolt](https://pass.hypha.coop):
   - After acceptance, add to `Member-Worker` group
@@ -89,6 +93,7 @@ This is a checklist for onboarding new members, workers, and contractors to the 
 
 1. Invite them to share their [weekly schedule](https://link.hypha.coop/schedules) (recommended without password)
 
+1. Add them to specific WG services (if needed)
 
 
 <!-- Links -->

--- a/onboarding.md
+++ b/onboarding.md
@@ -64,7 +64,7 @@ This is a checklist for onboarding new members, workers, and contractors to the 
 
 1. Collect encrypted (see [Sensitive Data](#sensitive-data) guide) [`TD1` and `TD1-ON` forms](https://www.canada.ca/en/revenue-agency/services/forms-publications/td1-personal-tax-credits-returns.html) to [Drive](https://link.hypha.coop/drive)
 
-1. Add member [as Employee in Wagepoint](#adding-a-new-employee) for payroll
+1. Add member to Clockify and [as Employee in Wagepoint](#adding-a-new-employee) for payroll
 
 #### Set up communications
 

--- a/onboarding.md
+++ b/onboarding.md
@@ -19,29 +19,89 @@ We interact with the public though the following channels:
 
 Instead of a physical place we have virtual office with the following spaces:
 
-- [Matrix Chat][matrix-chat]: `chat.tomesh.net`
-- [Loomio][loomio]: `loomio.hypha.coop`
-- [GitHub Organization](https://github.com/hyphacoop/), with a [task tracker][task-tracker]
+- [Matrix Chat][matrix-chat] (`chat.tomesh.net`)
+- [GitHub Organization][github-org], with a [task tracker][task-tracker]
 - [Google Drive][google-drive] (with both privileged 🔒 and public folders)
+- [Loomio][loomio] (`loomio.hypha.coop`)
 
 We also have the following "helper" tools to navigate our office spaces:
 
+- [Link Shortener][link-shortener] (`link.hypha.coop`)
 - [Service Inventory][service-inventory]
-- [Onboarding Checklist][onboarding-checklist]
-- [Link Shortener][link-shortener]: `link.hypha.coop`
+
+
+## Onboarding Checklist
+
+This is a checklist for onboarding new members, workers, and contractors to the Co-operative that should be done by the [Operations WG][operations]. 🚀
+
+**New members will provide...**:
+- A [Signal](https://www.signal.org/)-friendly number 
+- A [Matrix](https://matrix.org/) account (feel free to register on the [Toronto Mesh homeserver](https://chat.tomesh.net/#/register) where Hypha rooms exist)
+- A [Github](https://github.com/) account
+- A personal email for communications
+- A google-friendly email address (this could be a prior personal address or a hypha email can be used once set up)
+- For members and workers:
+  - A permanent or mailing address
+  - Their Social Insurance Number (SIN) 
+  - Completed `TD1` and `TD1-ON` forms 
+
+**Operations will...**
+
+### Set up employee record and payroll
+
+1. Collect information above and complete [employee record](https://link.hypha.coop/employees)
+
+1. Add member SIN to Passbolt and share access with `People Operations` group.
+   Change the member access to the entry as read-only, as this information is for recording keeping and the Member should not be able to modify it
+
+1. Collect encrypted (see [Sensitive Data](#sensitive-data) guide) [`TD1` and `TD1-ON` forms](https://www.canada.ca/en/revenue-agency/services/forms-publications/td1-personal-tax-credits-returns.html) to [Drive](https://link.hypha.coop/drive)
+
+1. Add member [as Employee in Wagepoint](#adding-a-new-employee) for payroll
+
+### Set up communications
+
+1. Add member to Signal `hyphacoop (Emergency Channel)` group
+
+1. Invite member to Matrix spaces:
+  - Private chat `#hyphacoop-private:tomesh.net`
+  - Public chat `#hyphacoop-open:tomesh.net`
+  - Community `+hyphacoop:tomesh.net`
+
+1. Set up a [`hypha.coop` email](https://link.hypha.coop/email) address:
+  - [Create new mailbox with Mailcow](#creating-new-inboxes-administrators)
+  - Set up initial forwarder
+  - Add to `members@`
+
+### Set up virtual office
+
+1. Invite to [Passbolt](https://pass.hypha.coop):
+  - After acceptance, add to `Member-Worker` group
+  - Ensure Member understands it is their responsibility to back-up their own private key
+  - Ensure Member understands when creating a password, they need to grant access to appropriate groups (e.g., when a password is meant to be shared between member-workers, otherwise others do not know that password exists in Passbolt)
+
+1. Invite to [GitHub Organization][github-org] and add to `Member-Workers` [GitHub Team](https://link.hypha.coop/teams)
+
+1. Add to [Google Drive][google-drive] and invite to calendars:
+    - https://link.hypha.coop/calendar
+    - https://link.hypha.coop/availability
+
+1. Invite to [Loomio](https://loomio.hypha.coop/)
+
+1. Invite them to share their [weekly schedule](https://link.hypha.coop/schedules) (recommended without password)
 
 
 
 <!-- Links -->
 [link-shortener]: https://link.hypha.coop
 [service-inventory]: https://link.hypha.coop/inventory
-[onboarding-checklist]: /guides.md#onboarding-checklist
 [accessing-em]: /guides.html#using-your-new-inbox-users
 [accessing-vm]: /guides.md#accessing-voicemail
 [managing-vm]: /guides.md#managing-voicemail-and-phone-forwarding
 [matrix-chat]: https://chat.tomesh.net/#/group/+hyphacoop:tomesh.net
 [loomio]: https://loomio.hypha.coop
 [task-tracker]: https://link.hypha.coop/tasks
+[github-org]: https://github.com/hyphacoop/
 [google-drive]: https://link.hypha.coop/drive
 [bb]: https://docs.google.com/drawings/d/1tpczePR5ky0EkdOGGdfU16irDz-gjdC61p2QGoAKhIE/edit
 [bb-folder]: https://drive.google.com/drive/folders/1XN1xw_3Lm6gWEuMla3MrbuK1VW0FmABt
+[operations]: http://localhost:4000/working-groups.html#operations

--- a/templates/checklist-offboarding.md
+++ b/templates/checklist-offboarding.md
@@ -1,70 +1,83 @@
-| Access 	| Active Member  	| Inactive  	| Exiting  	|
+# Checklist for offboarding
+
+
+
+## Going Inactive
+
+- [ ] Remove from: 
+  - [ ] Signal 
+  - [ ] Matrix active WG/initiative channels
+  - [ ] Email WG/initiative forwarders
+  - [ ] Passbolt groups 
+  - [ ] GitHub WG/initiative teams
+  - [ ] Desjardins 
+  - [ ] Wise 
+  - [ ] myCRA 
+  - [ ] GCOS
+- [ ] Remove admin access from: 
+  - [ ] Loomio (if they have?)
+  - [ ] Google Drive (messy)
+  - [ ] Google Calendar
+  - [ ] Payroll (handled in passbolt groups)
+- [ ] Remove SSH keys from:
+  - [ ] Servers
+
+## Leaving Hypha
+
+- [ ] Remove from: 
+  - [ ] Signal 
+  - [ ] Matrix all private channels and community
+  - [ ] Email members@ and WG/initiative forwarders
+  - [ ] Passbolt groups 
+  - [ ] GitHub organization (per-repo access as needed?)
+  - [ ] Google Drive (messy)
+  - [ ] Google Calendars
+  - [ ] Desjardins 
+  - [ ] Wise 
+  - [ ] myCRA 
+  - [ ] GCOS
+- [ ] Remove admin access from: 
+  - [ ] Loomio (if they have?)
+  - [ ] Payroll (handled in passbolt groups)
+- [ ] Remove SSH keys from:
+  - [ ] Servers
+  - [ ] VPN acccess
+
+## Chat of access and permissions for member-workers
+
+🏆 = admin priviliges (this is not fully represented, just to help distinguish access between Active and Inactive membership)
+✅ = access
+❌ = access removed
+
+| Access 	| Active Member  	| Inactive  	| Leaving Membership  |
 |-	|-	|-	|-	|
-| **Signal** 	|  ✅	|  	| ❌ 	|
+| **Signal** 	|  ✅	| ❌ 	| ❌ 	|
 | **Matrix** 	| 	|  	|  	|
 | Private 	| ✅	| ✅ 	| ❌ 	|
 | Public 	| ✅ 	| ✅ 	| ✅ 	|
 | Active initiatives/WGs 	| ✅	|  ❌ 	| ❌  	|
-| Community 	| ✅	|  	| ❌	|
+| Community [deprecated]	| ✅	|  ✅	| ❌	|
 | **Email** 	|  	|  	|  	|
-| Own inbox | ✅ |   | ❌   |
-| members@ 	| ✅	|  	| ❌  	|
-| other WG/initiative groups   | ✅ |   | ❌   |
+| Own inbox | ✅ | ✅ (monitored encourage out of office, not responding from email) | ❌   |
+| members@ 	| ✅	| ✅	| ❌  	|
+| other WG/initiative groups   | ✅ | ❌  | ❌   |
 | **Passbolt** 	|  	|  	|  	|
-| General   | ✅ |   | ❌  |
+| General   | ✅ | ✅ | ❌  |
 | Groups   | ✅ | ❌  | ❌  |
 | **GitHub Organization** 	|  	|  	|  	|
-| Member-Workers  | ✅ |   | ❌  |
+| Member-Workers  | ✅ | ✅  | ❌  |
 | Teams  | ✅ | ❌  | ❌  |
 | **Google Drive**  	|  	|  	|  	|
-| Access   | ✅ |   | ❌  |
-| Calendars   |   |   | ❌  |
-| **Loomio** 	| ✅ 	|  	| ❌ 	|
+| Access   | ✅ | ✅ (messy) | ❌  |
+| Calendars   | ✅🏆  | ✅  | ❌  |
+| **Loomio** 	| ✅🏆 | ✅ 	| ❌ 	|
 | **Finance**	|  	|  	|  	|
 | Payroll   | ✅🏆  | ✅  | ✅ (personal) |
-| Bank Acct   | ✅🏆 | ❌  | ❌  |
-| myCRA?   | ✅  | ❌  | ❌  |
-| that other one?   | ✅  | ❌  | ❌  |
-
-🏆
-✅
-❌
-  
-- Signal group
-- Matrix
-  - Private chat #hyphacoop-private:tomesh.net
-  - Public chat #hyphacoop-open:tomesh.net
-  - Community +hyphacoop:tomesh.net
-  - Other groups?
-- Email
-  - username@hypha.coop
-  - members@
-  - Other gorups
-- Passbolt
-  - General Access
-  - Groups
-- GitHub
-- Worker-Owner
-- Other Teams
-- Google Drive
-- Access
-- Calendar
-
-- Loomio
-
-- Payroll
-- Access to Bank Account
-
-- SSH keys
-
-- Availbility
-
-    off boarded “active” comms for wgs (chat, email fwds )
-    staying on members@
-    staying in org in gh, docs/calendar etc...
-
-I think as I understand server stuff we can also delineate in a similar manner? (E.g. still VPN, maybe not active access for controlling services?)
-
-Passbolt we might need to remove from specific groups? (E.g finances, ops) for access.
-
-- Weekly Scehdule https://link.hypha.coop/schedules (?)
+| Desjardins   | ✅🏆 | ❌  | ❌  |
+| Wise   | ✅🏆 | ❌  | ❌  |
+| myCRA business account  | ✅  | ❌  | ❌  |
+| myCRA personal link | ✅  | ❌  | ❌  |
+| GCOS account  | ✅  | ❌  | ❌  |
+| **Infra**	|  	|  	|  	|
+| SSH keys on server  | ✅🏆 | ❌  | ❌  |
+| VPN  | ✅ | ✅  | ❌  |

--- a/templates/checklist-offboarding.md
+++ b/templates/checklist-offboarding.md
@@ -1,6 +1,6 @@
-# Checklist for offboarding
+# Checklist - Offboarding
 
-
+This is a checklist for offboarding a member of the Co-operative 👋😢
 
 ## Going Inactive
 

--- a/templates/checklist-offboarding.md
+++ b/templates/checklist-offboarding.md
@@ -1,0 +1,70 @@
+| Access 	| Active Member  	| Inactive  	| Exiting  	|
+|-	|-	|-	|-	|
+| **Signal** 	|  ✅	|  	| ❌ 	|
+| **Matrix** 	| 	|  	|  	|
+| Private 	| ✅	| ✅ 	| ❌ 	|
+| Public 	| ✅ 	| ✅ 	| ✅ 	|
+| Active initiatives/WGs 	| ✅	|  ❌ 	| ❌  	|
+| Community 	| ✅	|  	| ❌	|
+| **Email** 	|  	|  	|  	|
+| Own inbox | ✅ |   | ❌   |
+| members@ 	| ✅	|  	| ❌  	|
+| other WG/initiative groups   | ✅ |   | ❌   |
+| **Passbolt** 	|  	|  	|  	|
+| General   | ✅ |   | ❌  |
+| Groups   | ✅ | ❌  | ❌  |
+| **GitHub Organization** 	|  	|  	|  	|
+| Member-Workers  | ✅ |   | ❌  |
+| Teams  | ✅ | ❌  | ❌  |
+| **Google Drive**  	|  	|  	|  	|
+| Access   | ✅ |   | ❌  |
+| Calendars   |   |   | ❌  |
+| **Loomio** 	| ✅ 	|  	| ❌ 	|
+| **Finance**	|  	|  	|  	|
+| Payroll   | ✅🏆  | ✅  | ✅ (personal) |
+| Bank Acct   | ✅🏆 | ❌  | ❌  |
+| myCRA?   | ✅  | ❌  | ❌  |
+| that other one?   | ✅  | ❌  | ❌  |
+
+🏆
+✅
+❌
+  
+- Signal group
+- Matrix
+  - Private chat #hyphacoop-private:tomesh.net
+  - Public chat #hyphacoop-open:tomesh.net
+  - Community +hyphacoop:tomesh.net
+  - Other groups?
+- Email
+  - username@hypha.coop
+  - members@
+  - Other gorups
+- Passbolt
+  - General Access
+  - Groups
+- GitHub
+- Worker-Owner
+- Other Teams
+- Google Drive
+- Access
+- Calendar
+
+- Loomio
+
+- Payroll
+- Access to Bank Account
+
+- SSH keys
+
+- Availbility
+
+    off boarded “active” comms for wgs (chat, email fwds )
+    staying on members@
+    staying in org in gh, docs/calendar etc...
+
+I think as I understand server stuff we can also delineate in a similar manner? (E.g. still VPN, maybe not active access for controlling services?)
+
+Passbolt we might need to remove from specific groups? (E.g finances, ops) for access.
+
+- Weekly Scehdule https://link.hypha.coop/schedules (?)

--- a/templates/checklist-offboarding.md
+++ b/templates/checklist-offboarding.md
@@ -28,6 +28,7 @@ This is a checklist for offboarding a member of the Co-operative 👋😢
   - [ ] Signal 
   - [ ] Matrix all private channels and community
   - [ ] Email members@ and WG/initiative forwarders
+  - [ ] Clockify
   - [ ] Passbolt groups 
   - [ ] GitHub organization (per-repo access as needed?)
   - [ ] Google Drive (messy)

--- a/templates/checklist-onboarding.md
+++ b/templates/checklist-onboarding.md
@@ -1,0 +1,23 @@
+# Checklist - Onboarding
+
+This is a checklist for onboarding a new Member to the Co-operative 🚀
+
+## Joining Hypha
+
+- [ ] Create Employee Acknowledgement and have them sign
+- [ ] Create employee record and collect required information 
+  - preferred pronouns 
+  - permanent and/or mailing address
+  - personal email 
+  - google-friendly email address 
+  - signal-friendly phone number
+  - SIN and completed `TD1` and `TD1-ON` forms 
+- [ ] Add to: 
+  - [ ] Signal 
+  - [ ] Matrix public, private channels and community
+  - [ ] Email members@ and WG/initiative forwarders
+  - [ ] Clockify
+  - [ ] Passbolt groups 
+  - [ ] GitHub organization (per-repo access as needed?)
+  - [ ] Google Drive (messy)
+  - [ ] Google Calendars


### PR DESCRIPTION
Moving checklist into "onboarding" page and updating it / seperating out what new members need vs. what operations wg does.
Should add something about a contract there...

- [x] initial restructure
- [x] add part about signing contract / agreement
- [x] add inactive status
- [x] add offboarding
