### PR TITLE
Add lockfile and use mainline html-proofer again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,3 @@
 source "https://rubygems.org"
 
-gem "html-proofer",
-  # Temporary fork to allow concurrency to be set via CLI.
-  # See: https://github.com/gjtorikian/html-proofer/pull/632
-  github: "patcon/html-proofer",
-  ref: "patch-1"
+gem "html-proofer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,39 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    ethon (0.13.0)
+      ffi (>= 1.15.0)
+    ffi (1.15.0)
+    html-proofer (3.19.0)
+      addressable (~> 2.3)
+      mercenary (~> 0.3)
+      nokogumbo (~> 2.0)
+      parallel (~> 1.3)
+      rainbow (~> 3.0)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
+    mercenary (0.4.0)
+    mini_portile2 (2.5.0)
+    nokogiri (1.11.3)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
+    nokogumbo (2.0.5)
+      nokogiri (~> 1.8, >= 1.8.4)
+    parallel (1.20.1)
+    public_suffix (4.0.6)
+    racc (1.5.2)
+    rainbow (3.0.0)
+    typhoeus (1.4.0)
+      ethon (>= 0.9.0)
+    yell (2.2.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  html-proofer
+
+BUNDLED WITH
+   2.0.2


### PR DESCRIPTION
Now the html-proofer contrib is merged (https://github.com/gjtorikian/html-proofer/pull/632), let's go back to using it directly.

Also, added the lockfile in. I don't know if there's a strong reason not to include it in version-control, since it's helpful to get on same page and make installs reproducible. Also, it would allow review apps to work on heroku, which is a tiny bonus. (They are currently set up and trying to work, but fail in every PR.)