### PR TITLE
adding fiscal-sponsorship page at the root level

### DIFF
--- a/fiscal-sponsorship.md
+++ b/fiscal-sponsorship.md
@@ -1,0 +1,153 @@
+# Fiscal Sponsorship
+
+Hypha is a Canadian Fiscal Host on the [Open Collective platform](https://opencollective.com/hyphacoopinc). Our fiscal sponsorship program allows Hypha to support our neighbours by providing a financial home, enabling them to accept and disburse money without having to create their own legal entity and bank account.
+
+Some examples of Collectives include:
+
+- Mutual aid and citizen groups
+- Meetup groups and other informal communities
+- Grassroot events and conferences
+- Shared resources supported by member contributions
+- Open source projects and other unincorporated collaborations
+
+Using the Open Collective platform, Collectives can keep transparent financial records and be accountable to funders while staying fully focused on carrying out their positive social impact activities.
+
+The terms of the fiscal sponsorship is described below in the legally binding [Fiscal Sponsorship Agreement](#fiscal-sponsorship-agreement). If you would like to have Hypha as a Fiscal Host, please read through the agreement carefully, then [visit here to apply](http://opencollective.com/hyphacoopinc/apply).
+
+We would like to acknowledge the [Canadian Worker Co-op Federation (CWCF)](https://canadianworker.coop/) for their financial support in helping us launch our fiscal sponsorship program.
+
+## Fiscal Sponsorship Agreement
+
+This Fiscal Sponsorship Agreement sets out how Hypha Worker Co-operative Inc. will provide an umbrella structure under which to operate your Collective, and the ways we will interact.
+
+1. **Parties.** These are the terms of the relationship entered into between:
+
+    - Hypha Worker Co-operative Inc. (Ontario Corporation No. 5019866) ("Us" or "Hypha"); and
+    - the Collective, which has agreed to these terms and conditions ("You" or "the Collective").
+
+    This agreement ("Agreement") is entered into with effect from the date ("Effective Date") that you confirm, by ticking the relevant box, that you have read and agree to these terms and that Hypha has accepted your request to include your Collective as part of Hypha and provide support to You for the purposes you described in your application.
+
+2. **Recitals.** The parties enter into this Agreement with reference to the following facts:
+
+    1. Hypha is a non-share capital worker co-operative based in Toronto. We are a non-profit organization.
+    
+    2. Hypha's mission is to cultivate collective growth and meaningful livelihoods through learning and building technologies together. We work in solidarity with our neighbours, where we support each other and provide safe harbour to imagine and create alternative futures ("Hypha's Mission").
+
+    3. The Collective, with its stated mission, meets the criteria for engaging Hypha as a fiscal sponsor as according to Exhibit A ("Protocols"). The Collective agrees to continue to align with Hypha's Mission in the future.
+
+    4. The Collective and Hypha mutually desire to enter a fiscal sponsorship relationship as according to the terms set out in this Agreement.
+
+    5. The parties agree that Hypha shall:
+
+        - receive funds for the Collective ("Funds") to be held by Hypha; and
+        - after discussing with You, control these funds for the use of the Collective (less any administrative charges, interest, and expenses).
+
+3. **Term.** This Agreement shall commence on the Effective Date, and will continue unless and until terminated under clause 10 of this Agreement.
+
+4. **Relationship.** Nothing in this Agreement means that the Collective or its members and/or agents is an agent or legal representative of Hypha for any purpose whatsoever except as provided in this Agreement.
+
+5. **Protocols.** Hypha has established certain protocols set out in Exhibit A. This sets out how Hypha shall manage and operate and deal with any funds.
+
+    Hypha will provide the Protocols to the Collective and may from time to time update the Protocols to assist Hypha in performing its obligations effectively.
+
+6. **Funds.** You may solicit unconditional gifts, contributions, sponsorships, and grants to Hypha for the purpose of the Collective, where the payer is not receiving any specific good or service in return.
+
+    The Collective understands, acknowledges and agrees that Hypha is not a registered charity or donee organisation, and that such funds collected by Hypha for the Collective will not have donation tax receipts issued for them and will not entitle the giver to a donation tax credit or a tax deduction.
+
+    If the Collective wishes to accept conditional payments, where the payer receives a specific good or service in return, you must provide notice in writing to Hypha so that we can ensure any applicable Harmonized Sales Tax (HST) or other taxes are applied.
+
+7. **Third party agreements.** If You want to enter into any agreement or obligation with a donor, sponsor, vendor or other third party, to provide or receive services beyond simply receiving a donor's financial contributions, you must first provide notice of the specific details to Us and obtain Hypha's prior written consent, as these agreements or obligations will legally be between Hypha and the third party.
+
+8. **Intellectual property.** Any and all tangible or intangible property, including intellectual property, such as copyrights of the Collective, belong to You. Furthermore, You represent that you have the power and right to advance the Collective. We acknowledge and agree that any trademarks, trade names, artwork, designs, logos, copy, and all other intellectual property  provided to Hypha by the Collective or its agents (for example, to be put on websites) belongs to the Collective and not to Us. For the avoidance of doubt, you should register ownership in the name of an individual associated with the Collective rather than in the name of Hypha.
+
+9. **The Collective.** Hypha will receive funds earmarked for support of the Collective, and make disbursements for expenses incurred in furtherance of the Collective. Beginning on the Effective Date, Hypha will place all such revenues received by Hypha and identified with the Collective into an account to be used for the benefit of the Collective's mission as that mission periodically may be defined by the Collective with the approval of Hypha. Hypha will exercise full control over the Collective's financial administration, management, and disbursement of the Fund.
+
+    For the avoidance of doubt, the parties note that all money will be reported as the income of Hypha, for both tax purposes and for purposes of Hypha's financial statements. Accordingly, Hypha is responsible for the processing and deposit in the Fund of all monies received for the Collective.
+
+    We will consult together around any payments to be made out to cover expenses of the Collective as detailed in the Protocols.
+
+10. **Termination.** Either Hypha or the Collective may terminate this Agreement on 30 days' written notice to the other party.
+
+    Upon a termination notice being given, the Collective will notify Hypha of how the funds will be dealt with, from the following three options:
+
+    - submit a request that the balance is paid out as a legitimate Collective expense (submitted and processed as per the Protocols);
+    - donate the funds of the Collective to another Collective hosted by Hypha; or
+    - Hypha will donate the funds to a Canadian registered charity.
+
+    If no notice is provided that elects one of these options by the Collective within the 30 days' written notice period, then the default is for the funds to be donated to a registered charity by Hypha (option 3).
+
+    In addition, if no member of the Collective has responded to a request for termination instructions by Hypha for a period of 12 months then the funds will automatically be donated to a registered charity by Hypha.
+
+11. **Notice.** Each notice under this Agreement shall be in writing and delivered personally or sent by post or email to the person at the address or email notified in writing from time to time.
+
+    A notice is deemed to be received:
+
+    - if delivered personally, when delivered;
+    - if posted, five business days after posting; or
+    - if sent by email, when actually received.
+
+12. **Disputes.** Before taking any Court action, a party must use best efforts to resolve any dispute under, or in connection with, the Agreement through good faith negotiations.
+
+    If there is a dispute between the parties in relation to this Agreement, either party may give the other party notice of the dispute.
+
+    Within 10 business days of receipt of the notice of dispute, the parties shall meet (in person or online) to endeavour to resolve the dispute.
+
+    If the dispute is not resolved within 20 business days of receipt of the notice of the dispute, either party may by notice to the other party refer the dispute to mediation, which will take place in person or online, with each party paying half of the cost of the mediation.
+
+    While any dispute remains unresolved, each party shall continue to perform this Agreement to the extent practicable, but without prejudice to their respective rights and remedies.
+
+13. **Liabilities & indemnification.** You are responsible for all activities of the Collective, including any financial or other liabilities, and you indemnify and hold harmless Hypha and its representatives from any and all claims, damages, losses, liabilities, costs and expenses (including reasonable attorney's fees) resulting from your performance of your obligations contained in this Agreement.
+
+    You also indemnify Us from any loss or liability resulting from injury (including sickness, disease or loss of life) to any person, or damage to any property of any third party at or as a result of your activities or the Collective.
+
+    You also indemnity Us in relation to any claims from third parties that you have violated any intellectual property laws.
+
+14. **Force majeure.** Neither party is liable to the other for any failure to perform its obligations under the Agreement to the extent caused by force majeure (which are events beyond the reasonable control of the affected party, such as a pandemic or natural disaster), provided that the affected party:
+
+    - immediately notifies the other party and provides full information about the force majeure;
+    - uses best efforts to overcome the force majeure; and
+    - continues to perform its obligations to the extent practicable.
+
+    Each party must take reasonable steps to mitigate any loss or damage, cost or expense it may suffer or incur arising out of anything done or not done by the other party under or in connection with the Agreement.
+
+15. **Jurisdiction.** This Agreement shall be construed and enforced in accordance with the laws of Ontario and Canada as they apply in Ontario.
+
+16. **Entire agreement & modification.** This Agreement supersedes any prior oral or written understandings or communications between the parties and constitutes the entire agreement of the parties with respect to the subject matter hereof. This Agreement may be amended by Us from time to time by posting new versions of these terms on our website and notifying You. By continuing to use the services of Hypha you will confirm that you agree to the modified terms.
+
+17. **Miscellaneous.** If there is any inconsistency between these terms and any other document submitted by You or any other arrangement with Us, these terms prevail unless otherwise agreed by Us in writing.
+
+    To waive a right under this Agreement, that waiver must be in writing and signed by the waiving party.
+
+    The parties are independent, and this Agreement does not create any partnership, agency or employment relationship between them.
+
+    If any provision of these terms and conditions is held by any court to be illegal, void or unenforceable, such determination shall not impair the enforceability of the remaining provisions.
+
+### Exhibit A: Protocols
+
+The following are the policies and processes of Hypha's fiscal sponsorship.
+
+**Criteria:** The Collective will provide evidence and Hypha will confirm that the Collective has met the criteria for engaging Hypha as a fiscal sponsor, being that the Collective has a mission that is value-aligned with Hypha's mission and carry out activities that create positive social impact.
+
+**Hypha fees and expenses:** The Collective will be required to pay membership fees ("Fees") and cover any expenses Hypha incurred on the Collective's behalf as a result of this Agreement. The Collective is responsible to pay from the Fund the Fees that consist of:
+
+- 5% of all of the funds deposited into the Fund, regardless of source, for purposes of becoming a Collective of Hypha and maintaining such membership; or
+- any specific amounts agreed between us in writing (due, for example, to there being a specific sum which we agree to look after for a specific fee); and
+- all interest earned on the Fund which will be retained in Hypha's general fund.
+
+**Payment processor expenses:** In addition to the Fees, the Collective is responsible for any merchant account credit card processing expenses incurred by Hypha as a result of administration of the Fund, which are directly related to the Collective's purpose. Such expenses shall be pulled directly from the Fund by Hypha.
+
+**Platform:** Upon execution of this Agreement, the Collective will be featured on Open Collective, an accounting and crowdfunding platform (the "Platform"), specifically on Hypha's page, which is owned by Hypha.
+
+Hypha will set the Collective up on the Platform such that the Collective will have its own dedicated page that tracks, in total transparency, the funds that it raises and the expenses it incurs in relation to the Collective.
+
+The Collective's page on the Platform will be linked to Hypha's Stripe account, PayPal account, TransferWise account, and bank account, so that Hypha has control over the funds received and disbursed under the Platform for purposes of the Collective. The Platform thus serves as a fundraising avenue for the Collective, enabling it to raise funds and be reimbursed for expenses incurred in relation to the Collective.
+
+The Platform makes the revenue and expenses of the Collective available to the public through a transparent ledger.
+
+**Disbursements:** In order to receive a disbursement from the funds raised to cover expenses incurred in furtherance of the Collective, those seeking payment must submit receipts/invoices onto the Platform for review by the Hypha staff, via the "Submit Expense" feature on the Collective's page.
+
+Upon Hypha's receipt of receipts/invoices, it will review all documentation to ensure the expenses incurred are valid. Upon approval by the Hypha staff, Hypha will reimburse those expenses to the payee through the Platform using PayPal, TransferWise, bank transfer, or another mutually agreed payment option. Each time Hypha reimburses the Collective for such expenses, the funds allocated to the Collective on the Platform will automatically decrease by the amount reimbursed.
+
+**Funds received & expenses paid outside platform:** In the event that the Collective receives funding outside of the Platform (that which does not go automatically and directly into the Fund), Hypha will use a feature enabled on the Platform to 'Manually Add Funds' to the Collective's balance. This means that Hypha will assign the funds received in the Fund destined to the Collective, thus increasing its budget. In the same fashion, if an expense is paid outside of the Platform by the Collective, because, for example, the recipient does not hold a PayPal account or another payout method is required, then Hypha will use the 'Mark as Paid' feature on the Platform, which allows Hypha to record that an expense has already been paid through a different method and that amount is automatically deducted from the Collective's Fund balance.
+
+_This page was last updated on April 4, 2023. You can see previous versions on [GitHub](https://github.com/hyphacoop/handbook/)._


### PR DESCRIPTION

`https://handbook.hypha.coop/Hypha-Worker-Co-operative/fiscal-sponsorship.html`
This didn't exist before `Hypha-Worker-Co-operative/`
This broke many external links linking in to us including from OC's site about our fiscal sponsorship policy
Quick fix at the handbook level by duplicating the page and inserting it where it used to be