### PR TITLE
Fix link to public offboarding checklist

### DIFF
--- a/Infrastructure/offboarding.md
+++ b/Infrastructure/offboarding.md
@@ -1,7 +1,7 @@
 
 # Offboarding 
 
-Follow the steps below to offboard an inactive or departing member, employee or contractor. Use the [offboarding checklist](../templates/checklist-offboarding.md) to track your work.
+Follow the steps below to offboard an inactive or departing member, employee or contractor. Use the [offboarding checklist](https://github.com/hyphacoop/handbook/blob/master/templates/checklist-offboarding.md) to track your work.
 ## Google Account
 These actions require the `Super Admin` permissions.
 ### Export user data


### PR DESCRIPTION
Re-ticketed from https://github.com/hyphacoop/organizing/issues/513#issuecomment-1827893853

Link on this page of the handbook doesn't work:
https://handbook.hypha.coop/templates/checklist-offboarding.md

Works going directly to the file on github.

FYI:
- on the ["templates" page](https://handbook.hypha.coop/Operations/templates.html#tasks), there is a private link (to the issue template in organizing-priv)
- on the ["offboarding" page](https://handbook.hypha.coop/templates/checklist-offboarding.md), there is a public link (currently broken, but fixed here)

For more coherence, might be worth linking the templates page to both public and private, but your call.