### PR TITLE
Add Distributed Press Publishing to GitHub Actions Workflow

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -23,6 +23,15 @@ jobs:
         npm install
         npx honkit build
 
+    - name: Publish to Distributed Press Production
+      if: ${{ github.ref == 'refs/heads/master' }}
+      uses: hyphacoop/actions-distributed-press@v1.1.0
+      with:
+        publish_dir: ./_book
+        dp_url: https://api.distributed.press
+        refresh_token: ${{ secrets.DISTRIBUTED_PRESS_PRODUCTION_TOKEN}}
+        site_url: handbook.hypha.coop
+
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
       with:


### PR DESCRIPTION
- Introduced a new step in the GitHub Actions workflow for deploying to Distributed Press Production
- This step is conditional on the master branch and uses hyphacoop/actions-distributed-press@v1.1.0
- Configured to publish the contents of the ./_book directory
- Included necessary configurations like Distributed Press URL, refresh token, and site URL


Currently Missing:
- [x] The Github secret for the refresh_token (`secrets.DISTRIBUTED_PRESS_PRODUCTION_TOKEN`)
- [x] DNS *stuff*