### PR TITLE
Add section on Distributed Web

### DIFF
--- a/handbook.md
+++ b/handbook.md
@@ -14,3 +14,7 @@ while sharing our structures and practices with the outside world as well.
 This resource is in perpetual beta and constantly changing. 
 If you see something that could be improved, 
 consider this your invitation to improve it!
+
+## Distributed Web
+
+This handbook is published using [Distributed Press](https://distributed.press/). You can [use it to publish](https://github.com/hyphacoop/api.distributed.press) on the p2p and distributed web too. Distributed Web: [ipns://handbook.hypha.coop/](https://handbook-hypha-coop.ipns.ipfs.hypha.coop/)


### PR DESCRIPTION
Now that the handbook is published on IPFS, I took the text found on hypha.coop's footer regarding DWeb publishing with Distributed Press and adapted it to the handbook's homepage.

> This handbook is published using [Distributed Press](https://distributed.press/). You can [use it to publish](https://github.com/hyphacoop/api.distributed.press) on the p2p and distributed web too. Distributed Web: [ipns://handbook.hypha.coop/](https://handbook-hypha-coop.ipns.ipfs.hypha.coop/)

I initially though of adding this text at the bottom of the sidebar next to `Published with HonKit` but instead went with the homepage to give it more visibility.

Adding it in the sidebar would require modifying the default HonKit theme and I am not convinced it is worth it.
