### PR TITLE
Update bylaws 3.7 Membership Decision Making and Voting

### DIFF
--- a/Hypha-Worker-Co-operative/bylaws.md
+++ b/Hypha-Worker-Co-operative/bylaws.md
@@ -223,9 +223,7 @@ Bylaws adopted: June 13, 2020
     
     Each active member of record at the time of the meeting is entitled
     to one and only one vote on any matter requiring membership voting.
-    Voting on resolutions happens by open ballot with abstensions are
-    recorded only as required. All elections to the board shall be by
-    secret ballot.
+    Voting on resolutions happens by secret ballot.
 
   1. **Action at a Meeting** – The president or other designee, as
     determined by the board of directors, shall chair at membership


### PR DESCRIPTION
**Membership voting is switching to secret ballot.**

Previously, only elections to the board (by the membership) were secret ballots. Other decisions made by the membership such as new member recommendation, employment matters, or budget decisions, were voted in open ballots. We are recommending to change all these member votes to secret ballots so all members can vote without social pressures or repercussions.

Note that:
- we are still allowed to temperature check in the open, but the binding vote is by secret ballot
- this does not cover day-to-day low stake operational decisions, like when to hold coffee break, is not considered a "member vote"
- board of directors will still vote in open ballots as it is now, as each director needs to be accountable to the membership