### PR TITLE
docs: Add salary adjustment instructions

### DIFF
--- a/Operations/salary-adjustments.md
+++ b/Operations/salary-adjustments.md
@@ -1,0 +1,19 @@
+# Salary Adjustment Processes
+
+## Yearly Cost Of Living Increase
+
+Every year we increase the base salary by `2.5%` to account for the increase in cost of living due to inflation.
+
+Here are the steps for increasing the salary:
+
+- Navigate to the Operations Planning Sheet
+- Navigate to the Salary Matrix Sheet
+- Increase the Min Base Salary by 2.5%
+- The other cells will update accordingly
+
+## Updating L/R Levels
+
+- Navigate to the Operations Planning Sheet
+- Navigate to the MEmber-Path Salaries Sheet
+- Find the row for the relevant member and update their values
+- The other cells will update accordingly

--- a/Operations/salary-adjustments.md
+++ b/Operations/salary-adjustments.md
@@ -8,7 +8,7 @@ Here are the steps for increasing the salary:
 
 - Navigate to the Operations Planning Sheet
 - Navigate to the Salary Matrix Sheet
-- Increase the Min Base Salary by 2.5%
+- Increase the Min Base Salary by the determined percent
 - The other cells will update accordingly
 
 ## Updating L/R Levels

--- a/Operations/salary-adjustments.md
+++ b/Operations/salary-adjustments.md
@@ -14,6 +14,6 @@ Here are the steps for increasing the salary:
 ## Updating L/R Levels
 
 - Navigate to the Operations Planning Sheet
-- Navigate to the MEmber-Path Salaries Sheet
+- Navigate to the Member-Path Salaries Sheet
 - Find the row for the relevant member and update their values
 - The other cells will update accordingly

--- a/Operations/salary-adjustments.md
+++ b/Operations/salary-adjustments.md
@@ -2,7 +2,7 @@
 
 ## Yearly Cost Of Living Increase
 
-Every year we increase the base salary by `2.5%` to account for the increase in cost of living due to inflation.
+Every year we increase the base salary by looking at the consumer price index for the last 12 months to account for the increase in cost of living due to inflation and use a "vibes based judgement" for the %increase..
 
 Here are the steps for increasing the salary:
 


### PR DESCRIPTION
BAsed on last weeks ops meeting.

Questions:
- Should we link directly to the sheets?
- Sheets have instructions for payroll and stuff, should we extract that to the handbook?
