### PR TITLE
Add new press: The Stanford Daily (Starling Lab)

### DIFF
--- a/Hypha-Worker-Co-operative/press.md
+++ b/Hypha-Worker-Co-operative/press.md
@@ -4,6 +4,7 @@ A selection of our press coverage and public talks.
 
 ## Press Coverage
 
+- [Green Library exhibit emphasizes the importance of transparency in the digital age](https://stanforddaily.com/2024/10/24/to-trust-or-not-to-trust-exhibit/); Charlotte Burks, The Stanford Daily, October 24, 2024
 - [The case against carbon emissions as a universal metric](https://www.ft.com/content/6e8224bf-879d-4111-95b7-278a258b30c5); Lee Harris, Financial Times, April 15 2024 (Hypha built the [Spice tool]([url](https://activestewardship.org/splice/)) mentioned in the article).
 - [Finding the Friends of HEK Basel: How to Bring Membership Online with a DAO](https://medium.com/@wac-lab/finding-the-friends-of-hek-basel-how-to-bring-membership-online-with-a-dao-1fd62425869f); WAC Lab - Web3 for the Arts and Culture, Dec 5, 2023
 - [Co-operatives, Work, and the Digital Economy: A Knowledge Synthesis Report](https://canadianworker.coop/worker-co-ops-and-the-sixth-principle/); Cultural Workers Organize, May 19, 2022


### PR DESCRIPTION
- [Green Library exhibit emphasizes the importance of transparency in the digital age](https://stanforddaily.com/2024/10/24/to-trust-or-not-to-trust-exhibit/)
> “To Trust or not to Trust: Authenticity in Design,” curated by Stanford’s [Starling Lab for Data Integrity](https://www.starlinglab.org/)