### PR TITLE
Add guidance to the membership application process

### DIFF
--- a/Hypha-Worker-Co-operative/member-application.md
+++ b/Hypha-Worker-Co-operative/member-application.md
@@ -1,16 +1,44 @@
-# Member Application Process
-Hypha is a worker co-operative that is governed and operated by its member-workers. Two weeks before probationary members become eligible for membership, i.e., two weeks before the completion of a full year as a probationary member, they should submit a completed member application form to `members@hypha.coop` in the body of an email or as a text attachment.
+## Membership at Hypha
+In a worker co-operative, members are sometimes referred to as “member-owners” because the members collectively own their co-operative.
 
-The application form consists of **three questions**. Probationary members should answer all questions to the best of their ability. There is no limit to the length, however, ideally the length of the completed application form will not exceed three pages at typical font sizes, to make reviews manageable.
+Hypha is incorporated as a non-share capital co-operative, which means that we do not have shares and so there is nothing tangible to “own” at Hypha, but being a member means sharing in the responsibility and ownership of the business itself even if you do not own a quantifiable portion of the company.
 
-Members will review submitted applications and vote to confirm membership of the applicants.
+Throughout your membership probationary period, you will likely get practice wearing multiple hats as you work in your practice area and contribute to an internal working group. Stepping into membership means adding a much bigger hat - it’s time to be an owner of the business.
 
-- Applications will not be evaluated on writing style as much as the content of the responses. 
-- The focus of the evaluation is on the ability of applicants to be good members and steer the cooperative into the future. Applicants' execution on client projects is not the focus of the evaluation. 
-- Evaluations will take into account applicants' level of experience and opportunities to participate in internal activities of the organization. Those who have had limited opportunities to participate in organization decisionmaking due to other cooperative priotiies (such as project work) will not be needlessly penalized for it.
-- Applicants must demonstrate a commitment to co-operative values in their responses.
+## Wearing different hats
+One of the challenges of moving from employment to membership is having to maintain two (or more) different relationships with the co-operative. 
 
-Applications should feel free to reach out to full members for support during the application process.
+### As an employee
+As an employee, you should be concerned about completing your work, growing in your career, and making sure that your compensation and benefits are appropriate for how much you contribute to the company. In non-co-op workplaces and in your membership probationary period, you are probably accustomed to operating like an employee and thinking about questions such as:
+* Is my job clearly defined and am I being given the necessary resources to do it?
+* Am I being given opportunities to grow in my career?
+* Is my overall compensation package fair?
+
+### As a member 
+Being the co-owner of a business comes with a lot of uncertainty - there is no one managing you or taking responsibility for choices that will impact your business and livelihood. It’s all on you and your peers. The flip-side of this is that being an owner means you also have enormous agency and control over your workplace and the direction it takes. This increase in uncertainty is not something everyone wants or appreciates, and it’s something you should think deeply about before choosing to apply for membership.
+
+As a member (and thus an owner and employer), you will need to be concerned with the wellbeing of all your employees, the strategic direction of the business, the company’s financial state, and more. Membership means continuing to think critically about your “employee concerns” while also becoming your own employer, with the agency to work with your fellow members to make Hypha a better place to be employed. It means stepping one level up and being the owner of a business, thinking about questions such as:
+* How do we attract and retain talented employees and contributors?
+* How will trends in our economy and industry impact Hypha, and how we can position our business to continue to be successful?
+* What can we afford to budget for payroll, business development, and operational overhead over the next fiscal year?
+
+Members are also eligible to be elected onto Hypha’s Board of Directors, which is yet another hat to wear. Members elect the Directors to define the strategic direction of the co-operative and hold senior members of the co-op (i.e. members who have chosen to hold more responsibility) accountable for their performance as leaders.
+
+## Membership application process
+Would-be members must first complete a full year of work for the co-op during their membership probationary period. This time is intended to onboard into both employment and membership possibility at Hypha, learning about the internal workings of the co-op, seeing how decisions are made, and gradually increasing your agency and contributions to Hypha.
+
+Once the probationary period is complete, you may apply for membership at any time. If you do not wish to apply for membership, you may be able to continue working for Hypha and the Board’s discretion, but this will be a decision made on a case-by-case basis. Worker co-operatives are meant to provide employment to members first, so Hypha will typically prioritize hiring people who intend to become members.
+
+The application form consists of three questions. Applicants should answer all questions to the best of their ability. There is no limit to the length, however, ideally the length of the completed application form will not exceed three pages at typical font sizes, to make reviews manageable. 
+
+Applicants should send an email to `members@hypha.coop` with their completed application (either in the body of the email or as an attachment). Members will review submitted applications and vote to confirm membership of the applicants.
+
+* Applications will not be evaluated on writing style as much as the content of the responses.
+* The focus of the evaluation is on the ability of applicants to be good members and steer the co-operative into the future. Applicants' execution on client projects is not the focus of the evaluation.
+* Evaluations will take into account applicants' level of experience and opportunities to participate in internal activities of the organization. Those who have had limited opportunities to participate in organization decisionmaking due to other cooperative priorities (such as project work) will not be needlessly penalized for it.
+* Applicants must demonstrate a commitment to co-operative values in their responses.
+Applicants should feel free to reach out to members for support during the application process.
+
 
 ## Member Application Form
 > v1.0 (2023-05)


### PR DESCRIPTION
This PR does not change the questions in the application or the process by which it happens.

It DOES add context for an applicant transitioning from 'employee' to 'owner' and how to think about that change.