### PR TITLE
Add gov structure to summary page

### DIFF
--- a/Hypha-Worker-Co-operative/board-of-directors.md
+++ b/Hypha-Worker-Co-operative/board-of-directors.md
@@ -1,6 +1,6 @@
 # Board of Directors
 
-See the [Governance structure](./governance-structure.md) page for information regarding the role of the board of directors.
+See the [Governance structure](governance-structure.md) page for information regarding the role of the board of directors.
 
 The current board includes four of our full members:
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -10,7 +10,8 @@
    * [Fiscal Sponsorship](./Hypha-Worker-Co-operative/fiscal-sponsorship.md)
    * [Member-workers](./Hypha-Worker-Co-operative/member-workers.md)
         * [Member Application Process](./Hypha-Worker-Co-operative/member-application.md)
-   * [Board of Directors](./Hypha-Worker-Co-operative/board-of-directors.md)
+   * [Governance Structure](./Hypha-Worker-Co-operative/governance-structure.md)
+        * [Board of Directors](./Hypha-Worker-Co-operative/board-of-directors.md)
    * [Look and Feel](./Hypha-Worker-Co-operative/look-and-feel.md)
    * [Press](./Hypha-Worker-Co-operative/press.md)
 


### PR DESCRIPTION
This PR addresses the following:
* The Governance structure page is missing from the summary page.
* The `Governance structure` link in [this section](https://handbook.hypha.coop/Hypha-Worker-Co-operative/board-of-directors.html#board-of-directors) brings up the markdown file.
