### PR TITLE
Add Co-op AI CWCF press coverave

### DIFF
--- a/Hypha-Worker-Co-operative/press.md
+++ b/Hypha-Worker-Co-operative/press.md
@@ -4,6 +4,7 @@ A selection of our press coverage and public talks.
 
 ## Press Coverage
 
+- [Co-op AI Aims to Offer an Alternative to Corporate Platforms](https://canadianworker.coop/co-op-ai-aims-to-offer-an-alternative-to-corporate-platforms/); Canadian Worker Co-operative Federation, August 2025
 - [How Can Data Cooperatives Help Build a Fair Data Economy?](https://www.projectliberty.io/wp-content/uploads/2025/01/PL_Practical_Data_Governance_Solutions_Report_v4.pdf); Report by Project Liberty Institute in collaboration with the Decentralization Research Center, January 2025  
 - [The case against carbon emissions as a universal metric](https://www.ft.com/content/6e8224bf-879d-4111-95b7-278a258b30c5); Lee Harris, Financial Times, April 15 2024 (Hypha built the [Spice tool]([url](https://activestewardship.org/splice/)) mentioned in the article).
 - [Finding the Friends of HEK Basel: How to Bring Membership Online with a DAO](https://medium.com/@wac-lab/finding-the-friends-of-hek-basel-how-to-bring-membership-online-with-a-dao-1fd62425869f); WAC Lab - Web3 for the Arts and Culture, Dec 5, 2023


### PR DESCRIPTION
- adds link to Co-op AI Aims to Offer an Alternative to Corporate Platforms post
- https://canadianworker.coop/co-op-ai-aims-to-offer-an-alternative-to-corporate-platforms/