### PR TITLE
Update member count to ten

### DIFF
--- a/Hypha-Worker-Co-operative/member-workers.md
+++ b/Hypha-Worker-Co-operative/member-workers.md
@@ -1,6 +1,6 @@
 # Member-workers
 
-Hypha has eleven **member-workers**, or **members**, all of which are full members. Members are expected to acknowledge the duties of their relationship with Hypha by signing the *Membership Acknowledgement*.
+Hypha has ten **member-workers**, or **members**, all of which are full members. Members are expected to acknowledge the duties of their relationship with Hypha by signing the *Membership Acknowledgement*.
 
 
 ## Being a Good Member

--- a/Hypha-Worker-Co-operative/member-workers.md
+++ b/Hypha-Worker-Co-operative/member-workers.md
@@ -1,6 +1,6 @@
 # Member-workers
 
-Hypha has eleven **member-workers**, or **members**, ten of which are full members and one is a member in their probationary period. Members are expected to acknowledge the duties of their relationship with Hypha by signing the *Membership Acknowledgement*.
+Hypha has eleven **member-workers**, or **members**, all of which are full members. Members are expected to acknowledge the duties of their relationship with Hypha by signing the *Membership Acknowledgement*.
 
 
 ## Being a Good Member


### PR DESCRIPTION
Updates the member-worker count in `Hypha-Worker-Co-operative/member-workers.md` from eleven to ten, reflecting an upcoming resignation.

This branch is based on #418, which corrects the now-outdated probationary-member wording ("all of which are full members"). The only additional change here is the count (eleven → ten). Merging this supersedes #418.

🤖 Generated with [Claude Code](https://claude.com/claude-code)