### PR TITLE
Remove Dependabot assignee

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,5 +10,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    assignees:
-      - "tripledoublev"


### PR DESCRIPTION
## Summary
- Remove the explicit npm Dependabot assignee so future dependency PRs are not assigned to tripledoublev.

## Testing
- git diff --check